### PR TITLE
MAIL-230: Set default timeout for client libs

### DIFF
--- a/swagger-config/marketing/javascript/templates/ApiClient.mustache
+++ b/swagger-config/marketing/javascript/templates/ApiClient.mustache
@@ -47,7 +47,7 @@ var querystring = require('querystring');
    * @type {Number}
    * @default 60000
    */
-  this.timeout = 60000;
+  this.timeout = 120000;
 
   /**
    * If set to false an additional timestamp parameter is added to all API GET calls to

--- a/swagger-config/marketing/php/templates/api.mustache
+++ b/swagger-config/marketing/php/templates/api.mustache
@@ -38,7 +38,11 @@ use {{invokerPackage}}\ObjectSerializer;
 
     public function __construct(ApiClient $config = null)
     {
-        $this->client = new Client();
+        $this->client = new Client([
+            'defaults' => [
+                'timeout' => 120.0
+            ]
+        ]);
         $this->headerSelector = new HeaderSelector();
         $this->config = $config ?: new ApiClient();
     }

--- a/swagger-config/marketing/python/templates/rest.mustache
+++ b/swagger-config/marketing/python/templates/rest.mustache
@@ -129,7 +129,8 @@ class RESTClientObject(object):
         post_params = post_params or {}
         headers = headers or {}
 
-        timeout = None
+        # default timeout of 120s
+        timeout = urllib3.Timeout(total=120.0)
         if _request_timeout:
             if isinstance(_request_timeout, (int, ) if six.PY3 else (int, long)):  # noqa: E501,F821
                 timeout = urllib3.Timeout(total=_request_timeout)

--- a/swagger-config/marketing/ruby/templates/api_client.mustache
+++ b/swagger-config/marketing/ruby/templates/api_client.mustache
@@ -51,7 +51,7 @@ module {{moduleName}}
       headers[:Authorization] = "Bearer #@access_token" if @is_oauth
 
       host = @server.length > 0 ? @host.sub('server', @server) : @host
-      conn = Excon.new(host + path, :headers => headers)
+      conn = Excon.new(host + path, :headers => headers, :read_timeout => 120, :write_timeout => 120)
 
       res = nil
       case http_method.to_sym.downcase

--- a/swagger-config/transactional/javascript/templates/ApiClient.mustache
+++ b/swagger-config/transactional/javascript/templates/ApiClient.mustache
@@ -1,6 +1,8 @@
 {{>licenseInfo}}
 var axios = require('axios');
 
+axios.defaults.timeout = 120000; // 120s
+
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}var {{baseName}} = require('./api/{{classname}}');
 {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 var exports = function (apiKey = '') {

--- a/swagger-config/transactional/javascript/templates/ApiClient.mustache
+++ b/swagger-config/transactional/javascript/templates/ApiClient.mustache
@@ -1,7 +1,7 @@
 {{>licenseInfo}}
 var axios = require('axios');
 
-axios.defaults.timeout = 120000; // 120s
+axios.defaults.timeout = 300000; // 300s
 
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}var {{baseName}} = require('./api/{{classname}}');
 {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}

--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -35,7 +35,11 @@ class ApiClient
 
     public function __construct()
     {
-        $this->requestClient = new RequestClient();
+        $this->requestClient = new RequestClient([
+            'defaults' => [
+                'timeout' => 120.0
+            ]
+        ]);
 
         // API Routes
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}        $this->{{#tags}}{{{name}}}{{/tags}} = new {{classname}}($this);

--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -37,7 +37,7 @@ class ApiClient
     {
         $this->requestClient = new RequestClient([
             'defaults' => [
-                'timeout' => 120.0
+                'timeout' => 300.0
             ]
         ]);
 

--- a/swagger-config/transactional/python/templates/api_client.mustache
+++ b/swagger-config/transactional/python/templates/api_client.mustache
@@ -64,9 +64,9 @@ class ApiClient(object):
         else:
             return res
 
-    def request(self, method, url, body=None, headers=None):
+    def request(self, method, url, body=None, headers=None, timeout=120.0):
         if method is 'POST':
-            return requests.post(url, data=json.dumps(body), headers=headers)
+            return requests.post(url, data=json.dumps(body), headers=headers, timeout=timeout)
         else:
             raise ValueError(
                 "http method must be `POST`"

--- a/swagger-config/transactional/python/templates/api_client.mustache
+++ b/swagger-config/transactional/python/templates/api_client.mustache
@@ -64,7 +64,7 @@ class ApiClient(object):
         else:
             return res
 
-    def request(self, method, url, body=None, headers=None, timeout=120.0):
+    def request(self, method, url, body=None, headers=None, timeout=300.0):
         if method is 'POST':
             return requests.post(url, data=json.dumps(body), headers=headers, timeout=timeout)
         else:

--- a/swagger-config/transactional/ruby/templates/api_client.mustache
+++ b/swagger-config/transactional/ruby/templates/api_client.mustache
@@ -55,7 +55,7 @@ module {{moduleName}}
       body[:key] = @api_key
 
       # send request
-      conn = Excon.new(url, :headers => {'Content-Type' => 'application/json'}, :read_timeout => 120, :write_timeout => 120)
+      conn = Excon.new(url, :headers => {'Content-Type' => 'application/json'}, :read_timeout => 300, :write_timeout => 300)
       res = conn.post(:body => body.to_json)
 
       # handle response

--- a/swagger-config/transactional/ruby/templates/api_client.mustache
+++ b/swagger-config/transactional/ruby/templates/api_client.mustache
@@ -55,7 +55,7 @@ module {{moduleName}}
       body[:key] = @api_key
 
       # send request
-      conn = Excon.new(url, :headers => {'Content-Type' => 'application/json'})
+      conn = Excon.new(url, :headers => {'Content-Type' => 'application/json'}, :read_timeout => 120, :write_timeout => 120)
       res = conn.post(:body => body.to_json)
 
       # handle response


### PR DESCRIPTION
### Description

Updates default request timeouts to match those of the corresponding API (120s for Marketing, 300s for Transactional).