### PR TITLE
Run workflows on pull requests as well as pushes

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -1,6 +1,7 @@
 name: 📦 Create Marketing Release
 
 on:
+  pull_request:
   push:
     paths:
       - 'spec/marketing.json'
@@ -10,8 +11,8 @@ on:
       - master
 
 env:
-  PUBLISH_INTERNAL: true # whether or not to push to git repos
-  PUBLISH_EXTERNAL: true # whether or not to push to package managers
+  PUBLISH_INTERNAL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} # push to git repos?
+  PUBLISH_EXTERNAL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} # push to package managers?
 
 jobs:
   validate:

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -1,6 +1,7 @@
 name: 📦 Create Transactional Release
 
 on:
+  pull_request:
   push:
     paths:
       - 'spec/transactional.json'
@@ -10,8 +11,8 @@ on:
       - master
 
 env:
-  PUBLISH_INTERNAL: true # whether or not to push to git repos
-  PUBLISH_EXTERNAL: true # whether or not to push to package managers
+  PUBLISH_INTERNAL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} # push to git repos?
+  PUBLISH_EXTERNAL: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} # push to package managers?
 
 jobs:
   validate:


### PR DESCRIPTION
### Description

Previously, workflows only ran on pushes to master. This PR runs workflows on all pull requests, albeit without publishing internally or externally.

### Known Issues
