### PR TITLE
Add initial CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,3 @@
+# These owners will be the default owners for everything in
+# the repo unless a later match takes precedence.
+* @Moishe @bipol-mailchimp @mcshanti


### PR DESCRIPTION
### Description

Adds a [CODEOWNERS](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners) file