### PR TITLE
MAIL-424: Add dev site rebuild workflow

### DIFF
--- a/.github/workflows/build-dev-site.yml
+++ b/.github/workflows/build-dev-site.yml
@@ -20,9 +20,15 @@ jobs:
       - name: POST Prod Build Hook
         run: curl -X POST -d {} ${{ env.NETLIFY_PROD_BUILD_HOOK }}
         if: env.REBUILD_PROD == 'true'
+        env:
+          NETLIFY_PROD_BUILD_HOOK: ${{ secrets.NETLIFY_PROD_BUILD_HOOK }}
       - name: POST Staging Build Hook
         run: curl -X POST -d {} ${{ env.NETLIFY_STAGING_BUILD_HOOK }}
         if: env.REBUILD_PROD != 'true'
+        env:
+          NETLIFY_STAGING_BUILD_HOOK: ${{ secrets.NETLIFY_STAGING_BUILD_HOOK }}
       - name: POST Dev Build Hook
         run: curl -X POST -d {} ${{ env.NETLIFY_DEV_BUILD_HOOK }}
         if: env.REBUILD_PROD == 'true'
+        env:
+          NETLIFY_DEV_BUILD_HOOK: ${{ secrets.NETLIFY_DEV_BUILD_HOOK }}

--- a/.github/workflows/build-dev-site.yml
+++ b/.github/workflows/build-dev-site.yml
@@ -6,7 +6,6 @@ on:
     paths:
       - 'spec/marketing.json'
       - 'spec/transactional.json'
-      - '.github/workflows/build-dev-site.yml'
     branches:
       - master
 

--- a/.github/workflows/build-dev-site.yml
+++ b/.github/workflows/build-dev-site.yml
@@ -1,0 +1,28 @@
+name: 🌐 Build Developer Site
+
+on:
+  pull_request:
+  push:
+    paths:
+      - 'spec/marketing.json'
+      - 'spec/transactional.json'
+      - '.github/workflows/build-dev-site.yml'
+    branches:
+      - master
+
+env:
+  REBUILD_PROD: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }} # true iff push to master
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: POST Prod Build Hook
+        run: curl -X POST -d {} ${{ env.NETLIFY_PROD_BUILD_HOOK }}
+        if: env.REBUILD_PROD == 'true'
+      - name: POST Staging Build Hook
+        run: curl -X POST -d {} ${{ env.NETLIFY_STAGING_BUILD_HOOK }}
+        if: env.REBUILD_PROD != 'true'
+      - name: POST Dev Build Hook
+        run: curl -X POST -d {} ${{ env.NETLIFY_DEV_BUILD_HOOK }}
+        if: env.REBUILD_PROD == 'true'

--- a/.github/workflows/build-dev-site.yml
+++ b/.github/workflows/build-dev-site.yml
@@ -2,10 +2,15 @@ name: 🌐 Build Developer Site
 
 on:
   pull_request:
+    paths:
+      - 'spec/marketing.json'
+      - 'spec/transactional.json'
+      - '.github/workflows/build-dev-site.yml'
   push:
     paths:
       - 'spec/marketing.json'
       - 'spec/transactional.json'
+      - '.github/workflows/build-dev-site.yml'
     branches:
       - master
 

--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -2,6 +2,10 @@ name: 📦 Create Marketing Release
 
 on:
   pull_request:
+    paths:
+      - 'spec/marketing.json'
+      - 'swagger-config/marketing/**.*'
+      - '.github/workflows/create-release-marketing.yml'
   push:
     paths:
       - 'spec/marketing.json'

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -2,6 +2,10 @@ name: 📦 Create Transactional Release
 
 on:
   pull_request:
+    paths:
+      - 'spec/transactional.json'
+      - 'swagger-config/transactional/**.*'
+      - '.github/workflows/create-release-transactional.yml'
   push:
     paths:
       - 'spec/transactional.json'


### PR DESCRIPTION
### Description

Adds a workflow for rebuilding the dev site, via Netlify build hooks.

Pushes to master should prompt a rebuild of prod and the dev site, while PR's should rebuild the staging branch, which is deployed to a separate Netlify build environment.

### Known Issues

This action only initiates the build; currently there isn't any feedback regarding whether or not the build was successful (at least here). There may be ways to wire this up using Netlify deploy notifications, but currently we have notifications set up in Slack and elsewhere so I think that it's alright that that info isn't surfaced here in GitHub.