### PR TITLE
Remove self from workflow rebuilds

### DIFF
--- a/.github/workflows/build-dev-site.yml
+++ b/.github/workflows/build-dev-site.yml
@@ -5,12 +5,10 @@ on:
     paths:
       - 'spec/marketing.json'
       - 'spec/transactional.json'
-      - '.github/workflows/build-dev-site.yml'
   push:
     paths:
       - 'spec/marketing.json'
       - 'spec/transactional.json'
-      - '.github/workflows/build-dev-site.yml'
     branches:
       - master
 

--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -5,12 +5,10 @@ on:
     paths:
       - 'spec/marketing.json'
       - 'swagger-config/marketing/**.*'
-      - '.github/workflows/create-release-marketing.yml'
   push:
     paths:
       - 'spec/marketing.json'
       - 'swagger-config/marketing/**.*'
-      - '.github/workflows/create-release-marketing.yml'
     branches:
       - master
 

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -5,12 +5,10 @@ on:
     paths:
       - 'spec/transactional.json'
       - 'swagger-config/transactional/**.*'
-      - '.github/workflows/create-release-transactional.yml'
   push:
     paths:
       - 'spec/transactional.json'
       - 'swagger-config/transactional/**.*'
-      - '.github/workflows/create-release-transactional.yml'
     branches:
       - master
 


### PR DESCRIPTION
### Description

Previously, each workflow file ran on PR / push to the file itself, which was redundant since Actions already enacts this. Having the path included led to the workflows running when they shouldn't, e.g. attempting to publish externally on a push [(link)](https://github.com/mailchimp/mailchimp-client-lib-codegen/actions/runs/267263069) that shouldn't have published a new version.