### PR TITLE
MAIL-450: Preserve git history by cloning client repo before pushing

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -459,10 +459,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: marketing-node
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-node.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-node.git
           git add --force .
           git commit -m "Update mailchimp-marketing-node to v${{ env.SPEC_VERSION }}"
           git push origin master --force
@@ -503,10 +503,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: marketing-php/MailchimpMarketing
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-php.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-php.git
           git add --force .
           git commit -m "Update mailchimp-marketing-php to v${{ env.SPEC_VERSION }}"
           git push origin master --force
@@ -553,10 +553,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: marketing-ruby
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-ruby.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-ruby.git
           git add --force .
           git commit -m "Update mailchimp-marketing-ruby to v${{ env.SPEC_VERSION }}"
           git push origin master --force
@@ -606,10 +606,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: marketing-python
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-python.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-python.git
           git add --force .
           git commit -m "Update mailchimp-marketing-python to v${{ env.SPEC_VERSION }}"
           git push origin master --force

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -445,10 +445,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: transactional-node
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-node.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-node.git
           git add --force .
           git commit -m "Update mailchimp-transactional-node to v${{ env.SPEC_VERSION }}"
           git push origin master --force
@@ -489,10 +489,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: transactional-php/MailchimpTransactional
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-php.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-php.git
           git add --force .
           git commit -m "Update mailchimp-transactional-php to v${{ env.SPEC_VERSION }}"
           git push origin master --force
@@ -539,10 +539,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: transactional-ruby
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-ruby.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-ruby.git
           git add --force .
           git commit -m "Update mailchimp-transactional-ruby to v${{ env.SPEC_VERSION }}"
           git push origin master --force
@@ -592,10 +592,10 @@ jobs:
         if: env.PUBLISH_INTERNAL == 'true'
         working-directory: transactional-python
         run: |
-          git init
+          rm -rf .git # remove any existing .git directory
+          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-python.git .git # copy from repo to track history
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git remote add origin https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-python.git
           git add --force .
           git commit -m "Update mailchimp-transactional-python to v${{ env.SPEC_VERSION }}"
           git push origin master --force


### PR DESCRIPTION
### Description

This PR preserves the git history of the client lib repos by cloning the `.git` directory before adding and pushing changes. Previously we were initting and force pushing on each deploy, such that the repos all only had 1 commit at any time.
