### PR TITLE
Update marketing spec, and add README about how to do it

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ venv*/
 dist/
 *.egg-info/
 .vscode/settings.json
+*~

--- a/spec/README.md
+++ b/spec/README.md
@@ -1,0 +1,31 @@
+# The spec directory
+
+This directory contains spec files used to generate SDKs and documentation.
+
+## Updating the Marketing Spec
+
+To update the marketing spec, follow these steps.
+
+Check the current version of the spec file:
+
+`cat spec/marketing.json |jq ".info.version"`
+
+Remember this number, it'll be something like `3.0.xx`
+
+Fetch the current spec file from production:
+
+`curl "https://api.mailchimp.com/schema/3.0/Swagger.json?expand" >spec/marketing.json`
+
+Using the editor of your choice, update the version in this file to the old version (that you got above) + 1.
+
+Create a PR.
+
+*Optional* When the PR is created, Github actions will run that create artifacts for each of the new SDKs. Pick an SDK .zip file and download it, then unzip it over an (empty) cloned SDK repo. Diff the unzipped files against HEAD of the SDK repo, but don't create a PR or push it -- this is just a check that the new SDKs will be reasonable and nothing's gone haywire. The changes you see in the SDK should mirror the changes you see in the spec file.
+
+Get approval, then push the PR.
+
+Ideally, update the version of the spec in production. This lives in Swagger.json in the monolith (only Mailchimp engineers can do this piece).
+
+## Updating the Transactional Spec
+
+_tbd_


### PR DESCRIPTION
### Description
The previous spec file was edited to make it possible to create SDKs. I backfilled most of the edits into the code that's used to serve the spec file in production. This PR contains that new spec file, as well as a README about how to manually keep it up-to-date.

Don’t bother diffing the spec files themselves because the formatting is different and everything gets weird (unless you want to download the files manually and pipe ’em through `json.tool` or what-have-you). Future updates to the spec file should be more readable though, since they’ll be coming from a consistent source.
