### PR TITLE
Fix git pipeline error in internal deploy action

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -460,7 +460,9 @@ jobs:
         working-directory: marketing-node
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-node.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-node.git repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .
@@ -504,7 +506,9 @@ jobs:
         working-directory: marketing-php/MailchimpMarketing
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-php.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-php.git repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .
@@ -555,7 +559,9 @@ jobs:
         working-directory: marketing-ruby
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-ruby.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-ruby.git repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .
@@ -608,7 +614,9 @@ jobs:
         working-directory: marketing-python
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-python.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-marketing-python.git repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -446,7 +446,9 @@ jobs:
         working-directory: transactional-node
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-node.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-node repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .
@@ -490,7 +492,9 @@ jobs:
         working-directory: transactional-php/MailchimpTransactional
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-php.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-php repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .
@@ -541,7 +545,9 @@ jobs:
         working-directory: transactional-ruby
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-ruby.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-ruby repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .
@@ -594,7 +600,9 @@ jobs:
         working-directory: transactional-python
         run: |
           rm -rf .git # remove any existing .git directory
-          git clone --bare https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-python.git .git # copy from repo to track history
+          git clone https://github:"$GITHUB_TOKEN"@github.com/mailchimp/mailchimp-transactional-python repo # clone repo to track history
+          mv repo/.git . # move cloned git history to root
+          rm -rf repo
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
           git add --force .


### PR DESCRIPTION
### Description

Clones full repo to allow for adding to the working tree. Previously, we were running `git clone --bare` which prevents adding to the working tree, causing the build step to fail.