### PR TITLE
Add MCDEV banner image to all client lib READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="./resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="./resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # mailchimp-client-lib-codegen

--- a/swagger-config/marketing/javascript/templates/README.mustache
+++ b/swagger-config/marketing/javascript/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Marketing – Node.js
 
 The official Node.js client library for the Mailchimp Marketing API

--- a/swagger-config/marketing/javascript/templates/README.mustache
+++ b/swagger-config/marketing/javascript/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Marketing – Node.js

--- a/swagger-config/marketing/php/templates/README.mustache
+++ b/swagger-config/marketing/php/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Marketing — PHP
 
 The official PHP client library for the Mailchimp Marketing API

--- a/swagger-config/marketing/php/templates/README.mustache
+++ b/swagger-config/marketing/php/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Marketing — PHP

--- a/swagger-config/marketing/python/templates/README.mustache
+++ b/swagger-config/marketing/python/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Marketing — Python
 
 The official Python client library for the Mailchimp Marketing API

--- a/swagger-config/marketing/python/templates/README.mustache
+++ b/swagger-config/marketing/python/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Marketing — Python

--- a/swagger-config/marketing/ruby/templates/README.mustache
+++ b/swagger-config/marketing/ruby/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Marketing — Ruby
 
 The official Ruby client library for the Mailchimp Marketing API (v1)

--- a/swagger-config/marketing/ruby/templates/README.mustache
+++ b/swagger-config/marketing/ruby/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Marketing — Ruby

--- a/swagger-config/transactional/javascript/templates/README.mustache
+++ b/swagger-config/transactional/javascript/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Transactional — Node.js

--- a/swagger-config/transactional/javascript/templates/README.mustache
+++ b/swagger-config/transactional/javascript/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Transactional — Node.js
 
 The official Node.js client library for the Mailchimp Transactional API (v1)

--- a/swagger-config/transactional/php/templates/README.mustache
+++ b/swagger-config/transactional/php/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Transactional — PHP
 
 The official PHP client library for the Mailchimp Transactional API (v1)

--- a/swagger-config/transactional/php/templates/README.mustache
+++ b/swagger-config/transactional/php/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Transactional — PHP

--- a/swagger-config/transactional/python/templates/README.mustache
+++ b/swagger-config/transactional/python/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Transactional — Python

--- a/swagger-config/transactional/python/templates/README.mustache
+++ b/swagger-config/transactional/python/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Transactional — Python
 
 The official Python client library for the Mailchimp Transactional API (v1)

--- a/swagger-config/transactional/ruby/templates/README.mustache
+++ b/swagger-config/transactional/ruby/templates/README.mustache
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+</p>
+
 # Mailchimp Transactional — Ruby
 
 The official Ruby client library for the Mailchimp Transactional API (v1)

--- a/swagger-config/transactional/ruby/templates/README.mustache
+++ b/swagger-config/transactional/ruby/templates/README.mustache
@@ -1,5 +1,7 @@
 <p align="center">
-  <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  <a href="https://mailchimp.com/developer/">
+    <img src="https://raw.githubusercontent.com/mailchimp/mailchimp-client-lib-codegen/master/resources/images/mcdev-banner.png" alt="Mailchimp Developer" width="100%" height="auto">
+  </a>
 </p>
 
 # Mailchimp Transactional — Ruby


### PR DESCRIPTION
### Description

Adds the following banner image to all client library READMEs, to match this repo and the dev site.

![Screen Shot 2020-11-05 at 10 36 56 AM](https://user-images.githubusercontent.com/1418487/98261941-044f8900-1f53-11eb-9efc-80817fac7f76.png)