### PR TITLE
Remove unnecessary sentence from send_at for messages/send

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -2680,7 +2680,7 @@
                 },
                 "send_at": {
                   "type": "string",
-                  "description": "when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately. An additional fee applies for scheduled email, and this feature is only available to accounts with a positive balance.",
+                  "description": "when this message should be sent as a UTC timestamp in YYYY-MM-DD HH:MM:SS format. If you specify a time in the past, the message will be sent immediately.",
                   "format": "date-time"
                 }
               }


### PR DESCRIPTION
### Description
Update the send_at description to remove an unnecessary/inaccurate sentence.
