### PR TITLE
Update guzzle to recent version for transactional SDKs

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.19",
+    "version": "1.0.20",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/transactional/php/templates/composer.mustache
+++ b/swagger-config/transactional/php/templates/composer.mustache
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/guzzle": "^6.2"
+        "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {
         "phpunit/phpunit": "^7",


### PR DESCRIPTION
### Description
Update Guzzle to version 7.2. See this PR for more information https://github.com/mailchimp/mailchimp-transactional-php/pull/4

### Known Issues
Note that this means the SDK will require PHP7.