### PR TITLE
[transactional-node] Bump axios to ^0.21.1 to patch security vulnerability

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.20",
+    "version": "1.0.21",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/transactional/javascript/templates/package.mustache
+++ b/swagger-config/transactional/javascript/templates/package.mustache
@@ -8,6 +8,6 @@
     "fs": false
   },
   "dependencies": {
-    "axios": "^0.19.2"
+    "axios": "^0.21.1"
   }
 }


### PR DESCRIPTION
### Description

More here: https://github.com/axios/axios/pull/3410.
Fixes https://github.com/mailchimp/mailchimp-transactional-node/pull/2.