### PR TITLE
Pin PHP version to 7.4 for marketing sdk tests

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -303,8 +303,9 @@ jobs:
           mkdir -p swagger-out/marketing-php
           unzip zip/mailchimp-marketing-php.zip -d swagger-out/marketing-php
 
-      - uses: php-actions/composer@v2
+      - uses: php-actions/composer@v5
         with:
+          php_version: 7.4
           command: install -d swagger-out/marketing-php/MailchimpMarketing
 
       - name: Install client dependencies


### PR DESCRIPTION
### Description
Composer was running PHP 8, which was causing problems with dependencies. Pin to 7.4.

### Known Issues
