### PR TITLE
Merge PR to use base64 encoding for API key in Ruby SDK

### DIFF
--- a/swagger-config/marketing/ruby/templates/api_client.mustache
+++ b/swagger-config/marketing/ruby/templates/api_client.mustache
@@ -2,6 +2,7 @@
 {{> api_info}}
 =end
 
+require 'base64'
 require 'json'
 require 'excon'
 
@@ -47,7 +48,7 @@ module {{moduleName}}
 
     def call_api(http_method, path, opts = {})
       headers = {'Content-Type' => "application/json"}
-      headers[:Authorization] = "Basic #{@api_key}" if @is_basic_auth
+      headers[:Authorization] = "Basic #{encoded_basic_token(@api_key)}" if @is_basic_auth
       headers[:Authorization] = "Bearer #@access_token" if @is_oauth
 
       host = @server.length > 0 ? @host.sub('server', @server) : @host
@@ -110,5 +111,12 @@ module {{moduleName}}
         fail "unknown collection format: #{collection_format.inspect}"
       end
     end
+
+   private
+
+     # Build base64 encoded token for basic auth.
+     def encoded_basic_token(api_key)
+       Base64.urlsafe_encode64("user:#{api_key}")
+     end
   end
 end


### PR DESCRIPTION
#### Description
API Keys in basic auth headers need to be base-64 encoded. This is from a PR that @cheldasan opened against the Ruby SDK.

#### Known Issues
None, but will be sure to diff the SDKs before merging.