### PR TITLE
When we updated the version of Guzzle to 7.2 we added an implicit dep…

### DIFF
--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -303,7 +303,7 @@ jobs:
 
       - uses: php-actions/composer@v5
         with:
-	  php_version: 7.4
+          php_version: 7.4
           command: install -d swagger-out/transactional-php/MailchimpTransactional
 
       - name: Install client dependencies

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -301,8 +301,9 @@ jobs:
           mkdir -p swagger-out/transactional-php
           unzip zip/mailchimp-transactional-php.zip -d swagger-out/transactional-php
 
-      - uses: php-actions/composer@v2
+      - uses: php-actions/composer@v5
         with:
+	  php_version: 7.4
           command: install -d swagger-out/transactional-php/MailchimpTransactional
 
       - name: Install client dependencies

--- a/swagger-config/marketing/php/templates/composer.mustache
+++ b/swagger-config/marketing/php/templates/composer.mustache
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",

--- a/swagger-config/transactional/php/templates/composer.mustache
+++ b/swagger-config/transactional/php/templates/composer.mustache
@@ -19,7 +19,7 @@
         }
     ],
     "require": {
-        "php": ">=5.5",
+        "php": ">=7.2",
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",


### PR DESCRIPTION
…endency on the php version being 7.2+. Lets make that dependency explicit

### Description
@stefantalen [noted](https://github.com/mailchimp/mailchimp-marketing-php/pull/10) that this library is not compatible with versions of PHP below 7.

We [did change the PHP version requirement to 7 when we upgraded our version of Guzzle](https://mailchimp.com/developer/release-notes/require-php7-marketing-transactional-sdks/), but should make that explicit in our composer file.

I set the required version to 7.2 to match Guzzle's [version guidance](https://github.com/guzzle/guzzle).
