### PR TITLE
Provide query parameters with POST PUT PATCH requests in our python m…

### DIFF
--- a/swagger-config/marketing/python/templates/api_client.mustache
+++ b/swagger-config/marketing/python/templates/api_client.mustache
@@ -123,11 +123,11 @@ class ApiClient(object):
         elif method == "OPTIONS":
             return requests.options(url, params=query_params, headers=headers, auth=auth)
         elif method == "POST":
-            return requests.post(url, data=json.dumps(body), headers=headers, auth=auth)
+            return requests.post(url, data=json.dumps(body), params=query_params, headers=headers, auth=auth)
         elif method == "PUT":
-            return requests.put(url, data=json.dumps(body), headers=headers, auth=auth)
+            return requests.put(url, data=json.dumps(body), params=query_params, headers=headers, auth=auth)
         elif method == "PATCH":
-            return requests.patch(url, data=json.dumps(body), headers=headers, auth=auth)
+            return requests.patch(url, data=json.dumps(body), params=query_params, headers=headers, auth=auth)
         elif method == "DELETE":
             return requests.delete(url, params=query_params, headers=headers, auth=auth)
         else:


### PR DESCRIPTION
…arketing SDK

### Description
@Dehorser found an issue in our Python SDK where we don't include query params for POST / PUT / PATCH 
see https://github.com/mailchimp/mailchimp-marketing-python/pull/3

You usually don't need the query params for POSTs, but there are exceptions like list.add_list_member()

### Testing
I re-generated the python SDK locally, and confirmed that after making this change I was able to pass the `skip_merge_validation` parameter when adding a list member

### Changes for Python Marketing SDK users
This doesn't change the method signatures for the Python SDK

If users were including keyword arguments with their POST/PUT/PATCH requests, those arguments weren't sent as query parameters before this change, and will be after. This could result in changes to their API responses.