### PR TITLE
Add PHP version requirement to README

### DIFF
--- a/swagger-config/marketing/php/templates/README.mustache
+++ b/swagger-config/marketing/php/templates/README.mustache
@@ -48,6 +48,8 @@ require_once('/path/to/{{packagePath}}/vendor/autoload.php');
 
 ## Quick Start
 
+### Note that this SDK requires PHP 7.2 or above.
+
 ```php
 require_once('/path/to/{{packagePath}}/vendor/autoload.php');
 

--- a/swagger-config/transactional/php/templates/README.mustache
+++ b/swagger-config/transactional/php/templates/README.mustache
@@ -48,6 +48,8 @@ require_once('/path/to/{{packagePath}}/vendor/autoload.php');
 
 ## Quick Start
 
+### Note that this SDK requires PHP 7.2 or above.
+
 ```php
 require_once('/path/to/{{packagePath}}/vendor/autoload.php');
 


### PR DESCRIPTION
### Description
We require PHP 7.2 in our composer files; also added a note about this to our README for marketing & transactional.

### Known Issues
