### PR TITLE
Handle collection serialization of query parameters

### DIFF
--- a/swagger-config/marketing/php/templates/api.mustache
+++ b/swagger-config/marketing/php/templates/api.mustache
@@ -158,7 +158,7 @@ use {{invokerPackage}}\ObjectSerializer;
         // query params
         {{#collectionFormat}}
         if (is_array(${{paramName}})) {
-            $queryParams['{{baseName}}'] = ${{paramName}};
+            $queryParams['{{baseName}}'] = ObjectSerializer::serializeCollection(${{paramName}}, '{{collectionFormat}}');
         } else
         {{/collectionFormat}}
         if (${{paramName}} !== null) {

--- a/tests/marketing-php/MarketingTest.php
+++ b/tests/marketing-php/MarketingTest.php
@@ -16,6 +16,32 @@ class MarketingTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals("Everything's Chimpy!", $resp->health_status);
     }
 
+    public function testIncludeExclude()
+    {
+        $client = new MailchimpMarketing\ApiClient();
+        $client->setConfig([
+            'apiKey' => getenv('MARKETING_API_KEY'),
+            'server' => getenv('MARKETING_SERVER'),
+        ]);
+
+        # include fields
+        $resp = $client->root->getRoot(["account_id"]);
+        $this->assertObjectHasAttribute("account_id", $resp);
+        $this->assertObjectNotHasAttribute("login_id", $resp);
+
+        $resp = $client->root->getRoot(["account_id", "login_id"]);
+        $this->assertObjectHasAttribute("account_id", $resp);
+        $this->assertObjectHasAttribute("login_id", $resp);
+
+        $resp = $client->root->getRoot(null, ["account_id"]);
+        $this->assertObjectNotHasAttribute("account_id", $resp);
+        $this->assertObjectHasAttribute("login_id", $resp);
+
+        $resp = $client->root->getRoot(null, ["account_id", "login_id"]);
+        $this->assertObjectNotHasAttribute("login_id", $resp);
+        $this->assertObjectNotHasAttribute("account_id", $resp);
+    }
+
     public function testOAuth()
     {
         $client = new MailchimpMarketing\ApiClient();


### PR DESCRIPTION
### Description
It seems like `csv` type `collectionFormat` parameters do not get encoded correctly:
https://github.com/swagger-api/swagger-codegen/issues/10046

The generated code seems accept the array as the query parameter if given, instead of respecting the `collectionFormat`.  The current behavior seems to encode the parameters into the `multi` format by default, due to `Guzzle`s handling of arrays.

```php
>>> $field_parameters = ["fields" => ["id", "name"]];
=> [
     "fields" => [
       "id",
       "name",
     ],
   ]
>>> $query = \GuzzleHttp\Psr7\build_query($field_parameters);
=> "fields=id&fields=name"
```

This is technically an invalid query parameter for our `fields` parameter, since we ask for a `csv` type, or `fields=id,name`.

After this change:
```php
php > print_r($mailchimp->lists->getListInterestCategories('548e911d96', ['categories.id','categories.title']));
stdClass Object
(
    [categories] => Array
        (
            [0] => stdClass Object
                (
                    [id] => 329f93d9cf
                    [title] => Interests
                )

        )

)
```
Before this change:
```php
php > print_r($mailchimp->lists->getListInterestCategories('548e911d96', ['categories.id','categories.title']));
stdClass Object
(
    [categories] => Array
        (
            [0] => stdClass Object
                (
                    [title] => Interests
                )

        )

)
```
### Known Issues
https://github.com/mailchimp/mailchimp-client-lib-codegen/issues/67