### PR TITLE
Use '==' instead of 'is' for string comparison in python transactional library

### DIFF
--- a/swagger-config/transactional/python/templates/api_client.mustache
+++ b/swagger-config/transactional/python/templates/api_client.mustache
@@ -65,7 +65,7 @@ class ApiClient(object):
             return res
 
     def request(self, method, url, body=None, headers=None, timeout=300.0):
-        if method is 'POST':
+        if method == 'POST':
             return requests.post(url, data=json.dumps(body), headers=headers, timeout=timeout)
         else:
             raise ValueError(


### PR DESCRIPTION
### Description
@rtr3 noted a warning because we were using `is` to compare strings instead of `==`. Fixed this in the template file.

### Known Issues
