### PR TITLE
Bump version (forgot in previous PR)

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.24",
+    "version": "1.0.25",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",


### PR DESCRIPTION
### Description
Publishing the SDKs from PR https://github.com/mailchimp/mailchimp-client-lib-codegen/pull/152 failed because I forgot to bump the version number; bump it now.

### Known Issues
