### PR TITLE
Send Post Body as `json` instead of `form_params`

### DIFF
--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -76,7 +76,7 @@ class Configuration
 
         // prepare request params
         $postUrl = $this->getHost() . $path;
-        $postBody = [ 'form_params' => $body ];
+        $postBody = [ 'json' => $body ];
 
         // set output format
         $defaultOutputFormat = $this->getDefaultOutputFormat();


### PR DESCRIPTION


### Description
while upgrading from mandrill/mandrill to mailchimp/transactional , I observed from the API logs that the empty `[]` passed as `template_content` in `->messages->sendTemplate` was removed in the request which cause an API response error. I found this SF https://stackoverflow.com/a/57410642 answer that suggests changing `form_params` to `json` which worked when i tested. 
The current workaround i'm using is sending `[["name" => "", "content" => ""]]` as  `template_content`
### Known Issues
