### PR TITLE
[APIC-755] Update documentation, fix readme

### DIFF
--- a/swagger-config/marketing/ruby/templates/README.mustache
+++ b/swagger-config/marketing/ruby/templates/README.mustache
@@ -6,7 +6,7 @@
 
 # Mailchimp Marketing — Ruby
 
-The official Ruby client library for the Mailchimp Marketing API (v1)
+The official Ruby client library for the Mailchimp Marketing API
 
 ## Installation
 
@@ -111,4 +111,3 @@ Mailchimp Marketing libraries are available in the following languages:
   <img src="https://github.com/mailchimp/mailchimp-client-lib-codegen/blob/master/resources/images/lang_python.png?raw=true" width="44" height="44">
   </a>
 </div>
-


### PR DESCRIPTION
### Description
Adds enums to our campaign statuses, landing page statuses, and fixes documentation around the `activity-feed` endpoint.

### Known Issues
https://github.com/mailchimp/mailchimp-marketing-ruby/pull/10