### PR TITLE
[APIC-757] Fix workflows to push to master branch of codegen repos

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -470,7 +470,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --force .
           git commit -m "Update mailchimp-marketing-node to v${{ env.SPEC_VERSION }}"
-          git push origin main --force
+          git push origin master --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}
@@ -517,7 +517,7 @@ jobs:
           git add --force .
           git commit -m "Update mailchimp-marketing-php to v${{ env.SPEC_VERSION }}"
           git tag -a v${{ env.SPEC_VERSION }} -m "Update v${{ env.SPEC_VERSION }}"
-          git push origin main --follow-tags --force
+          git push origin master --follow-tags --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}
@@ -569,7 +569,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --force .
           git commit -m "Update mailchimp-marketing-ruby to v${{ env.SPEC_VERSION }}"
-          git push origin main --force
+          git push origin master --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}
@@ -624,7 +624,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --force .
           git commit -m "Update mailchimp-marketing-python to v${{ env.SPEC_VERSION }}"
-          git push origin main --force
+          git push origin master --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -456,7 +456,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --force .
           git commit -m "Update mailchimp-transactional-node to v${{ env.SPEC_VERSION }}"
-          git push origin main --force
+          git push origin master --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}
@@ -503,7 +503,7 @@ jobs:
           git add --force .
           git commit -m "Update mailchimp-transactional-php to v${{ env.SPEC_VERSION }}"
           git tag -a v${{ env.SPEC_VERSION }} -m "Update v${{ env.SPEC_VERSION }}"
-          git push origin main --follow-tags --force
+          git push origin master --follow-tags --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}
@@ -555,7 +555,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --force .
           git commit -m "Update mailchimp-transactional-ruby to v${{ env.SPEC_VERSION }}"
-          git push origin main --force
+          git push origin master --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}
@@ -610,7 +610,7 @@ jobs:
           git config --local user.name "GitHub Action"
           git add --force .
           git commit -m "Update mailchimp-transactional-python to v${{ env.SPEC_VERSION }}"
-          git push origin main --force
+          git push origin master --force
         env:
           GITHUB_TOKEN: ${{ secrets.GIT_HUB_TOKEN }}
           SPEC_VERSION: ${{ needs.validate.outputs.version }}

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,13 +171,13 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.26",
+    "version": "1.0.27",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",
       "email": "apihelp@mailchimp.com"
     },
-    "x-permalink": "https://github.com/mailchimp/mailchimp-client-lib-codegen/blob/master/spec/transactional.json"
+    "x-permalink": "https://github.com/mailchimp/mailchimp-client-lib-codegen/blob/main/spec/transactional.json"
   },
   "host": "mandrillapp.com",
   "basePath": "/api/1.0",


### PR DESCRIPTION
### Description
My previous PR was a bit greedy with the find & replace - our codegen libraries are still using `master` as the default branch, and I was trying to push to a `main` brach on them, which does not exist.

This PR should fix this for the `marketing` and `transactional` repos.
### Known Issues
