### PR TITLE
Remove Dev build hook (since only prod / staging currently exist)

### DIFF
--- a/.github/workflows/build-dev-site.yml
+++ b/.github/workflows/build-dev-site.yml
@@ -29,8 +29,3 @@ jobs:
         if: env.REBUILD_PROD != 'true'
         env:
           NETLIFY_STAGING_BUILD_HOOK: ${{ secrets.NETLIFY_STAGING_BUILD_HOOK }}
-      - name: POST Dev Build Hook
-        run: curl -X POST -d {} ${{ env.NETLIFY_DEV_BUILD_HOOK }}
-        if: env.REBUILD_PROD == 'true'
-        env:
-          NETLIFY_DEV_BUILD_HOOK: ${{ secrets.NETLIFY_DEV_BUILD_HOOK }}


### PR DESCRIPTION
### Description

Currently the Dev build hook is unused, because we only have prod (`mc-developer-prod.netlify.app`) and staging (`mc-developer.netlify.app`).