### PR TITLE
Ruby - allow posting query parameters

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.28",
+    "version": "1.0.29",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/marketing/ruby/templates/api_client.mustache
+++ b/swagger-config/marketing/ruby/templates/api_client.mustache
@@ -57,7 +57,7 @@ module {{moduleName}}
       res = nil
       case http_method.to_sym.downcase
       when :post, :put, :patch, :delete
-        res = conn.request(:method => http_method, :body => opts[:body])
+        res = conn.request(:method => http_method, :query => opts[:query_params], :body => opts[:body])
       when :get
         res = conn.get(:query => opts[:query_params])
       end

--- a/swagger-config/marketing/ruby/templates/gemspec.mustache
+++ b/swagger-config/marketing/ruby/templates/gemspec.mustache
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
+  s.test_files    = []
   s.executables   = []
   s.require_paths = ["lib"]
 end

--- a/swagger-config/transactional/ruby/templates/gemspec.mustache
+++ b/swagger-config/transactional/ruby/templates/gemspec.mustache
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'autotest-fsevent', '~> 0.2', '>= 0.2.12'
 
   s.files         = `find *`.split("\n").uniq.sort.select { |f| !f.empty? }
-  s.test_files    = `find spec/*`.split("\n")
+  s.test_files    = []
   s.executables   = []
   s.require_paths = ["lib"]
 end


### PR DESCRIPTION
### Description
Making fixes from two PRs

This one https://github.com/mailchimp/mailchimp-marketing-ruby/pull/9
Because I was doing some local builds of the gem. Doesn't look like the `test_files` configuration is used by us.

And https://github.com/mailchimp/mailchimp-marketing-ruby/pull/6
Which fixes the fact that query parameters were left out as options for POST/PATCH/PUT/DELETE even though the API does support some query params on those methods.

I rebuilt the ruby gem locally and used it to POST list members with the skip_merge_validation query parameter. Seems like everything should work and be backwards compatible with current callers, but Ruby is not my strong suit.