### PR TITLE
PHP SDK: Use GuzzleHttp\Psr7\Query::build

### DIFF
--- a/swagger-config/marketing/php/templates/api.mustache
+++ b/swagger-config/marketing/php/templates/api.mustache
@@ -23,6 +23,7 @@ use GuzzleHttp\Client;
 use GuzzleHttp\ClientInterface;
 use GuzzleHttp\Exception\RequestException;
 use GuzzleHttp\Psr7\MultipartStream;
+use GuzzleHttp\Psr7\Query;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\RequestOptions;
 use {{invokerPackage}}\ApiException;
@@ -251,7 +252,7 @@ use {{invokerPackage}}\ObjectSerializer;
                 $httpBody = \GuzzleHttp\json_encode($formParams);
 
             } else {
-                $httpBody = \GuzzleHttp\Psr7\build_query($formParams);
+                $httpBody = Query::build($formParams);
             }
         }
 
@@ -286,7 +287,7 @@ use {{invokerPackage}}\ObjectSerializer;
             $headers
         );
 
-        $query = \GuzzleHttp\Psr7\build_query($queryParams);
+        $query = Query::build($queryParams);
         return new Request(
             '{{httpMethod}}',
             $this->config->getHost() . $resourcePath . ($query ? "?{$query}" : ''),

--- a/swagger-config/marketing/php/templates/composer.mustache
+++ b/swagger-config/marketing/php/templates/composer.mustache
@@ -23,7 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/psr7": "^1.7 || ^2.0"
+        "guzzlehttp/psr7": "^1.7 || ^2.0",
         "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {

--- a/swagger-config/marketing/php/templates/composer.mustache
+++ b/swagger-config/marketing/php/templates/composer.mustache
@@ -23,7 +23,6 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
-        "guzzlehttp/psr7": "<2.0",
         "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {

--- a/swagger-config/marketing/php/templates/composer.mustache
+++ b/swagger-config/marketing/php/templates/composer.mustache
@@ -23,6 +23,7 @@
         "ext-curl": "*",
         "ext-json": "*",
         "ext-mbstring": "*",
+        "guzzlehttp/psr7": "^1.7 || ^2.0"
         "guzzlehttp/guzzle": "^7.2"
     },
     "require-dev": {


### PR DESCRIPTION
With the new `GuzzleHttp\Psr7` version 2.0 the helper functions are no
longer available.
I replaced the `build_query` function with the `Query::build` function.
With this change, the lock to `GuzzleHttp\Psr7` < 2.0 is no longer
required, which resolved #193 .
