### PR TITLE
New github actions to allow testing on forks

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -1,11 +1,6 @@
 name: 📦 Create Marketing Release
 
 on:
-  pull_request:
-    paths:
-      - 'spec/marketing.json'
-      - 'swagger-config/marketing/**.*'
-      - '.github/workflows/create-release-marketing.yml'
   push:
     paths:
       - 'spec/marketing.json'

--- a/.github/workflows/test-marketing.yml
+++ b/.github/workflows/test-marketing.yml
@@ -1,0 +1,189 @@
+name: Test Marketing Client Libraries
+
+on:
+  workflow_run:
+    workflows: ["Validate and Generate Marketing Client Libraries"]
+    types:
+      - completed
+jobs:
+  test-node:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@mailchimp'
+
+      - name: Prepare Build & Publishing Tools
+        run: npm install
+
+      - uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: mailchimp-marketing-node.zip
+          path: zip
+
+      - name: Unzip build artifact
+        run: |
+          mkdir -p swagger-out/marketing-javascript
+          unzip zip/mailchimp-marketing-node.zip -d swagger-out/marketing-javascript
+
+      - name: Install client
+        working-directory: swagger-out/marketing-javascript
+        run: npm install
+
+      - name: Run test suite
+        run: npm run test -- MarketingTest.test.js
+        env:
+          MARKETING_API_KEY: ${{ secrets.MARKETING_API_KEY }}
+          MARKETING_ACCESS_TOKEN: ${{ secrets.MARKETING_ACCESS_TOKEN }}
+          MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}
+
+  test-php:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: actions/checkout@v2
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: mailchimp-marketing-php.zip
+          path: zip
+
+      - name: Unzip build artifact
+        run: |
+          mkdir -p swagger-out/marketing-php
+          unzip zip/mailchimp-marketing-php.zip -d swagger-out/marketing-php
+
+      - uses: php-actions/composer@v5
+        with:
+          php_version: 7.4
+          command: install -d swagger-out/marketing-php/MailchimpMarketing
+
+      - name: Install client dependencies
+        run: |
+          wget -O phpunit https://phar.phpunit.de/phpunit-9.phar
+          chmod +x phpunit
+          ./phpunit --version
+
+      - name: Run test suite
+        working-directory: tests/marketing-php
+        run: |
+          MARKETING_API_KEY=${{ secrets.MARKETING_API_KEY }} \
+          MARKETING_SERVER=${{ secrets.MARKETING_SERVER }} \
+          MARKETING_ACCESS_TOKEN=${{ secrets.MARKETING_ACCESS_TOKEN }} \
+          phpunit MarketingTest.php
+        env:
+          MARKETING_API_KEY: ${{ secrets.MARKETING_API_KEY }}
+          MARKETING_ACCESS_TOKEN: ${{ secrets.MARKETING_ACCESS_TOKEN }}
+          MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}
+
+  test-ruby:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: actions/checkout@v2
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: mailchimp-marketing-ruby.zip
+          path: zip
+
+      - name: Unzip build artifact
+        run: |
+          mkdir -p swagger-out/marketing-ruby
+          unzip zip/mailchimp-marketing-ruby.zip -d swagger-out/marketing-ruby
+
+      - name: Set up Ruby 2.6
+        uses: actions/setup-ruby@v1
+        with:
+          ruby-version: '2.6'
+
+      - name: Install client dependencies
+        run: gem install rspec
+
+      - name: Install client
+        working-directory: swagger-out/marketing-ruby
+        run: |
+          gem build MailchimpMarketing.gemspec --output=MailchimpMarketing-test.gem
+          gem install ./MailchimpMarketing-test.gem
+
+      - name: Run test suite
+        run: |
+          cd tests/marketing-ruby
+          MARKETING_API_KEY=${{ secrets.MARKETING_API_KEY }} \
+          MARKETING_SERVER=${{ secrets.MARKETING_SERVER }} \
+          MARKETING_ACCESS_TOKEN=${{ secrets.MARKETING_ACCESS_TOKEN }} \
+          rspec MarketingTest_spec.rb
+        env:
+          MARKETING_API_KEY: ${{ secrets.MARKETING_API_KEY }}
+          MARKETING_ACCESS_TOKEN: ${{ secrets.MARKETING_ACCESS_TOKEN }}
+          MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}
+
+  test-python:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
+      - uses: actions/checkout@v2
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - name: Install Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - uses: dawidd6/action-download-artifact@b9571484721e8187f1fd08147b497129f8972c74
+        with:
+          workflow: ${{ github.event.workflow_run.workflow_id }}
+          run_id: ${{ github.event.workflow_run.id }}
+          name: mailchimp-marketing-python.zip
+          path: zip
+
+      - name: Unzip build artifact
+        run: |
+          mkdir -p swagger-out/marketing-python
+          unzip zip/mailchimp-marketing-python.zip -d swagger-out/marketing-python
+
+      - name: Install client dependencies
+        run: pip install -U python-dotenv
+
+      - name: Install client
+        working-directory: swagger-out/marketing-python
+        run: python3 setup.py install --user
+
+      - name: Run test suite
+        run: |
+          cd tests/marketing-python
+          MARKETING_API_KEY=${{ secrets.MARKETING_API_KEY }} \
+          MARKETING_SERVER=${{ secrets.MARKETING_SERVER }} \
+          MARKETING_ACCESS_TOKEN=${{ secrets.MARKETING_ACCESS_TOKEN }} \
+          python3 MarketingTest.py
+        env:
+          MARKETING_API_KEY: ${{ secrets.MARKETING_API_KEY }}
+          MARKETING_ACCESS_TOKEN: ${{ secrets.MARKETING_ACCESS_TOKEN }}
+          MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}

--- a/.github/workflows/validate-and-generate-marketing.yml
+++ b/.github/workflows/validate-and-generate-marketing.yml
@@ -1,0 +1,238 @@
+name: Validate and Generate Marketing Client Libraries
+
+on:
+  pull_request:
+    types: [ labeled ]
+
+jobs:
+  validate:
+    if: ${{ github.event.label.name == 'test-marketing' }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.set-version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: NPM Install
+        run: npm install
+      - name: Validate Marketing Spec
+        run: npx @apidevtools/swagger-cli validate spec/marketing.json
+      - name: Set Version
+        id: set-version
+        run: node utils/actions/setVersionVar.js --api=marketing
+
+  setup-cache:
+    if: ${{ github.event.label.name == 'test-marketing' }}
+    runs-on: ubuntu-latest
+    needs: [validate]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+      - name: Install Codegen CLI
+        if: steps.init-cache-mc.outputs.cache-hit != 'true'
+        run: |
+          mkdir .cache
+          wget https://repo1.maven.org/maven2/io/swagger/swagger-codegen-cli/2.4.7/swagger-codegen-cli-2.4.7.jar -O .cache/swagger-codegen-cli.jar
+          java -jar .cache/swagger-codegen-cli.jar help
+
+  generate-node:
+    if: ${{ github.event.label.name == 'test-marketing' }}
+    runs-on: ubuntu-latest
+    needs: [validate, setup-cache]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - uses: actions/setup-node@v1
+        with:
+          node-version: '12.x'
+          registry-url: 'https://registry.npmjs.org'
+          scope: '@mailchimp'
+
+      - name: Generate → marketing-javascript
+        run: |
+          npm install
+          node utils/actions/updateLangConfig.js --api=marketing --lang=javascript --specVersion=${{ env.SPEC_VERSION }}
+          npm run generate:javascript:marketing
+        env:
+          SPEC_VERSION: ${{ needs.validate.outputs.version }}
+
+      - name: Rename marketing-javascript → marketing-node
+        working-directory: swagger-out
+        run: |
+          mv marketing-javascript marketing-node
+
+      - name: Zip build artifact → marketing-node
+        working-directory: swagger-out/marketing-node
+        run: zip -r mailchimp-marketing-node.zip .
+
+      - name: Upload build artifact → marketing-node
+        uses: actions/upload-artifact@v1
+        with:
+          name: mailchimp-marketing-node.zip
+          path: swagger-out/marketing-node/mailchimp-marketing-node.zip
+
+  generate-php:
+    if: ${{ github.event.label.name == 'test-marketing' }}
+    runs-on: ubuntu-latest
+    needs: [validate, setup-cache]
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Generate → marketing-php
+        run: |
+          npm install
+          node utils/actions/updateLangConfig.js --api=marketing --lang=php --specVersion=${{ env.SPEC_VERSION }}
+          npm run generate:php:marketing
+        env:
+          SPEC_VERSION: ${{ needs.validate.outputs.version }}
+
+      - name: Zip build artifact → marketing-php
+        working-directory: swagger-out/marketing-php
+        run: zip -r mailchimp-marketing-php.zip .
+
+      - name: Upload build artifact → marketing-php
+        uses: actions/upload-artifact@v1
+        with:
+          name: mailchimp-marketing-php.zip
+          path: swagger-out/marketing-php/mailchimp-marketing-php.zip
+
+  generate-ruby:
+    if: ${{ github.event.label.name == 'test-marketing' }}
+    runs-on: ubuntu-latest
+    needs: [validate, setup-cache]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Generate → marketing-ruby
+        run: |
+          npm install
+          node utils/actions/updateLangConfig.js --api=marketing --lang=ruby --specVersion=${{ env.SPEC_VERSION }}
+          npm run generate:ruby:marketing
+        env:
+          SPEC_VERSION: ${{ needs.validate.outputs.version }}
+
+      - name: Zip build artifact → marketing-ruby
+        working-directory: swagger-out/marketing-ruby
+        run: zip -r mailchimp-marketing-ruby.zip .
+
+      - name: Upload build artifact → marketing-ruby
+        uses: actions/upload-artifact@v1
+        with:
+          name: mailchimp-marketing-ruby.zip
+          path: swagger-out/marketing-ruby/mailchimp-marketing-ruby.zip
+
+  generate-python:
+    if: ${{ github.event.label.name == 'test-marketing' }}
+    runs-on: ubuntu-latest
+    needs: [validate, setup-cache]
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Initialize Marketing Cache
+        id: init-cache-mc
+        uses: actions/cache@v1
+        with:
+          path: .cache
+          key: cache-dir
+
+      - name: Cache node_modules
+        uses: actions/cache@v1
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: ~/.npm
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('**/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Generate → marketing-python
+        run: |
+          npm install
+          node utils/actions/updateLangConfig.js --api=marketing --lang=python --specVersion=${{ env.SPEC_VERSION }}
+          npm run generate:python:marketing
+        env:
+          SPEC_VERSION: ${{ needs.validate.outputs.version }}
+
+      - name: Zip build artifact → marketing-python
+        working-directory: swagger-out/marketing-python
+        run: zip -r mailchimp-marketing-python.zip .
+
+      - name: Upload build artifact → marketing-python
+        uses: actions/upload-artifact@v1
+        with:
+          name: mailchimp-marketing-python.zip
+          path: swagger-out/marketing-python/mailchimp-marketing-python.zip


### PR DESCRIPTION
### Description
A few changes to our github actions:

1.  📦 Create Marketing Release => only runs when pushing to main
2. Two new actions are created:
* `Test Marketing Client Libraries` => uses `workflow_run`, allowing secrets, to run the build through our test suite.
* `Validate and Generate Marketing Client Libraries` => validates the code, generates the libraries, and adds them to the cache

The new validation actions is activated only on pull requests, or if a `test-marketing` label is added.  The testing action only runs when the validation completes, and because it uses `workflow_run`, it allows secrets.

**Note** - I'm using a few actions from the Github Actions marketplace, so there may be security implications to consider here.

Non-internal actions i'm using:
https://github.com/haya14busa/action-workflow_run-status
https://github.com/dawidd6/action-download-artifact
### Known Issues
