### PR TITLE
Fix github action

### DIFF
--- a/.github/workflows/test-marketing.yml
+++ b/.github/workflows/test-marketing.yml
@@ -7,6 +7,7 @@ on:
       - completed
 jobs:
   test-node:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
@@ -44,6 +45,7 @@ jobs:
           MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}
 
   test-php:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
@@ -91,6 +93,7 @@ jobs:
           MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}
 
   test-ruby:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94
@@ -141,6 +144,7 @@ jobs:
           MARKETING_SERVER: ${{ secrets.MARKETING_SERVER }}
 
   test-python:
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - uses: haya14busa/action-workflow_run-status@967ed83efa565c257675ed70cfe5231f062ddd94


### PR DESCRIPTION
### Description
We will attempt to test the repo, even if we haven't added the label (thus, the validation step was skipped).

I didn't account for the fact that cla-bot adds a label as well, and thought that `workflow_run` would only run when the previous step succeeded.  That is not the case.

### Known Issues
