### PR TITLE
added verify_txt_key to the changed endpoints

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -4925,6 +4925,10 @@
                   "valid_signing": {
                     "type": "boolean",
                     "description": "whether this domain can be used to authenticate mail, either for itself or as a custom signing domain. If this is false but spf and dkim are both valid, you will need to verify the domain before using it to authenticate mail"
+                  },
+                  "verify_txt_key": {
+                    "type": "string",
+                    "description": "a unique key used to verify a domain by adding a TXT record. Append this key to 'mandrill_verify.' and add it to your domain's TXT records to verify."
                   }
                 }
               }
@@ -5033,6 +5037,10 @@
                 "valid_signing": {
                   "type": "boolean",
                   "description": "whether this domain can be used to authenticate mail, either for itself or as a custom signing domain. If this is false but spf and dkim are both valid, you will need to verify the domain before using it to authenticate mail"
+                },
+                "verify_txt_key": {
+                  "type": "string",
+                  "description": "a unique key used to verify a domain by adding a TXT record. Append this key to 'mandrill_verify.' and add it to your domain's TXT records to verify."
                 }
               }
             }
@@ -5140,6 +5148,10 @@
                 "valid_signing": {
                   "type": "boolean",
                   "description": "whether this domain can be used to authenticate mail, either for itself or as a custom signing domain. If this is false but spf and dkim are both valid, you will need to verify the domain before using it to authenticate mail"
+                },
+                "verify_txt_key": {
+                  "type": "string",
+                  "description": "a unique key used to verify a domain by adding a TXT record. Append this key to 'mandrill_verify.' and add it to your domain's TXT records to verify."
                 }
               }
             }


### PR DESCRIPTION
### Description
We recently added the ability to verify domains via TXT record. A new parameter in the API response, verify_txt_key has been added to the /senders/check-domain, /senders/add-domain, and /senders/domains endpoints. The key contains a unique string that can be appended to 'mandrill_verify.' and added the domains' TXT records to verify. 
