### PR TITLE
Remove the terms 'blacklist' and 'whitelist' from the API reference.

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.32",
+    "version": "1.0.33",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",


### PR DESCRIPTION
### Description
Removing the terms "blacklist" and "whitelist" and changing them to "denylist" and "allowlist" to keep up to date with the terminology used in app now. This only applies to the summaries and descriptions in the reference. Certain instances will remain in the reference, such as the /whitelist/ API endpoints, or any API responses that contain the old terms. 