### PR TITLE
Throw ApiException when API requests fails

### DIFF
--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -13,7 +13,6 @@ use GuzzleHttp\Client as RequestClient;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Exception\RequestException;
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}
-use {{invokerPackage}}\ApiException;
 use {{invokerPackage}}\Api\{{classname}};{{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 class Configuration

--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -13,6 +13,7 @@ use GuzzleHttp\Client as RequestClient;
 use GuzzleHttp\Psr7;
 use GuzzleHttp\Exception\RequestException;
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}
+use {{invokerPackage}}\ApiException;
 use {{invokerPackage}}\Api\{{classname}};{{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
 class Configuration
@@ -109,7 +110,10 @@ class Configuration
 
             return $resp;
         } catch (RequestException $e) {
-            return $e->hasResponse() ? Psr7\str($e->getResponse()) : $e;
+            if ($e->hasResponse()) {
+                throw new ApiException( 'Request Failed', $e->getCode(), $e->getResponse()->getHeaders(), $e->getResponse()->getBody()->getContents() );
+            }
+            return $e;
         }
     }
 }


### PR DESCRIPTION
### Description
Sending an invalid [message request](https://mailchimp.com/developer/transactional/api/messages/send-new-message/) causes a HTTP 500 error.
```php
require_once '/path/to/MailchimpTransactional/vendor/autoload.php';

$mailchimp = new MailchimpTransactional\ApiClient();
$mailchimp->setApiKey('YOUR_API_KEY');

// Message value undefined.
$response = $mailchimp->messages->send([]);
print_r($response);
```

The `$response` for this request would be the following. This is not a very useful format to use as it would require parsing the string to figure out the error.

```
HTTP/1.1 500 Internal Server Error
server: nginx/1.12.2
date: Tue, 07 Sep 2021 09:57:33 GMT
content-type: application/json; charset=utf-8
transfer-encoding: chunked
access-control-allow-origin: *
access-control-allow-methods: POST, GET, OPTIONS
access-control-allow-headers: Content-Type
access-control-allow-credentials: false

{"status":"error","code":-1,"name":"ValidationError","message":"You must specify a message value"}
```

By throwing an `ApiException`  this would allow for using a try catch when sending a message. The code would look like something as follows.

```php
require_once '/path/to/MailchimpTransactional/vendor/autoload.php';

$mailchimp = new MailchimpTransactional\ApiClient();
$mailchimp->setApiKey('YOUR_API_KEY');

try {
	// Message value undefined.
	$response = $mailchimp->messages->send([]);
	print_r($response);
} catch ( \MailchimpTransactional\ApiException $e ) {
	// Print error message.
	echo \get_class( $e ) . ' - ' . $e->getMessage();
}
```

This seems to be the first use of `ApiException`. I am happy to get suggestions to improve the exception message.

### Known Issues
https://github.com/mailchimp/mailchimp-client-lib-codegen/issues/188
https://github.com/mailchimp/mailchimp-client-lib-codegen/issues/184