### PR TITLE
Return the exception directly in mailchimp-transactional-php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.38
+* A change was made to `mailchimp-transactional-php` - the API client will now always return an `Exception`, instead of an `Exception` or a string, when the API returns an error. Having to parse the response as a string was found to be a bit clunky.
+
 ### 1.0.37
 * Added a changelog, which will be used to describe changes to both transactional and marketing client libraries.
 

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.37",
+    "version": "1.0.38",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -109,7 +109,7 @@ class Configuration
 
             return $resp;
         } catch (RequestException $e) {
-            return $e->hasResponse() ? Psr7\str($e->getResponse()) : $e;
+            return $e;
         }
     }
 }


### PR DESCRIPTION
### Description
Per https://github.com/mailchimp/mailchimp-client-lib-codegen/pull/245

Opening a separate PR for this change.  This is slightly awkward for existing users who may be expecting a string from the error states, however, the contract is currently a string _or_ a concrete exception, so I'm hoping that this isn't too rough.

There is also an existing PR on the repository asking for this change.

### Known Issues
https://github.com/mailchimp/mailchimp-transactional-php/pull/5
