### PR TITLE
Fix changlog placement for custom output directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.39
+* Fixes the output directory for the Changelog for the php client library
+
 ### 1.0.38
 * A change was made to `mailchimp-transactional-php` - the API client will now always return an `Exception`, instead of an `Exception` or a string, when the API returns an error. Having to parse the response as a string was found to be a bit clunky.
 
@@ -9,6 +12,9 @@
 * Added a changelog, which will be used to describe changes to both transactional and marketing client libraries.
 
 ## Marketing
+
+### 3.0.64
+* Fixes the output directory for the Changelog for the php client library
 
 ### 3.0.63
 * Added a changelog, which will be used to describe changes to both transactional and marketing client libraries.

--- a/generate-sdks
+++ b/generate-sdks
@@ -63,8 +63,6 @@ generate_for_language() {
 
     output_root="${output_dir}"
 
-    cp ./CHANGELOG.md "${output_root}/CHANGELOG.md"
-
     if [ "${sdk_name}" == "marketing-php" ]; then
         output_root="${output_root}/MailchimpMarketing"
         rm -rf "${output_root}/lib/Model"
@@ -87,6 +85,7 @@ generate_for_language() {
 
     # add additional files to client root dir
     cp ./LICENSE "${output_root}"
+    cp ./CHANGELOG.md "${output_root}/CHANGELOG.md"
 
     rm -f -r "${output_root}/.github"
     mkdir "${output_root}/.github"

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -171,7 +171,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.38",
+    "version": "1.0.39",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",


### PR DESCRIPTION
### Description
I made a mistake in #249 - the `output_dir` changes for the `php` client libraries, and thus, my Changelog wasn't being persisted to those artifacts.  

### Known Issues
