### PR TITLE
Add ability to override the default axios timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Transactional
 
 ### 1.0.42
-* Added a `setDefaultTimeoutMs` method to the transactional node client. This allows users to override the default timeout for API requests, which is set to 5 minutes by default.
+* Added a `setDefaultTimeoutMs` method to the node client. This allows users to override the default timeout for API requests, which is set to 5 minutes by default.
 
 ### 1.0.41
 * Updated the "reject_reasons" response for /messages/send and /messages/send-template to correctly use "hard-bounce" and "soft-bounce" instead of the previously stated "hard_bounce" and "soft_bounce".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Transactional
 
 ### 1.0.42
-* Added a `setDefaultTimeoutMs` method to the client. This allows users to override the default timeout for API requests, which is set to 5 minutes by default.
+* Added a `setDefaultTimeoutMs` method to the transactional node client. This allows users to override the default timeout for API requests, which is set to 5 minutes by default.
 
 ### 1.0.41
 * Updated the "reject_reasons" response for /messages/send and /messages/send-template to correctly use "hard-bounce" and "soft-bounce" instead of the previously stated "hard_bounce" and "soft_bounce".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.42
+* Added a `setDefaultTimeoutMs` method to the client. This allows users to override the default timeout for API requests, which is set to 5 minutes by default.
+
 ### 1.0.41
 * Updated the "reject_reasons" response for /messages/send and /messages/send-template to correctly use "hard-bounce" and "soft-bounce" instead of the previously stated "hard_bounce" and "soft_bounce".
 

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -177,7 +177,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.41",
+    "version": "1.0.42",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/transactional/javascript/templates/ApiClient.mustache
+++ b/swagger-config/transactional/javascript/templates/ApiClient.mustache
@@ -66,8 +66,7 @@ exports.prototype.setDefaultOutputFormat = function (outputFormat) {
 };
 
 exports.prototype.setDefaultTimeoutMs = function (timeoutMs) {
-  var _this = this;
-  _this.axios.defaults.timeout = timeoutMs;
+  axios.defaults.timeout = timeoutMs;
 }
 
 // The default API client implementation.

--- a/swagger-config/transactional/javascript/templates/ApiClient.mustache
+++ b/swagger-config/transactional/javascript/templates/ApiClient.mustache
@@ -65,6 +65,11 @@ exports.prototype.setDefaultOutputFormat = function (outputFormat) {
   }
 };
 
+exports.prototype.setDefaultTimeoutMs = function (timeoutMs) {
+  var _this = this;
+  _this.axios.defaults.timeout = timeoutMs;
+}
+
 // The default API client implementation.
 exports.instance = function (apiKey) {
   return new exports(apiKey);


### PR DESCRIPTION
### Description
Allow users of the node transactional SDK to set the timeout for axios calls.

### Known Issues
