### PR TITLE
updated reject_reasons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.41
+* Updated the "reject_reasons" response for /messages/send and /messages/send-template to correctly use "hard-bounce" and "soft-bounce" instead of the previously stated "hard_bounce" and "soft_bounce".
+
 ### 1.0.40
 * Added the new /allowlists/ series of endpoints and the /exports/allowlist endpoint to the API reference
 

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -177,7 +177,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.40",
+    "version": "1.0.41",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",
@@ -2976,8 +2976,8 @@
                     "type": "string",
                     "description": "the reason for the rejection if the recipient status is \"rejected\"",
                     "enum": [
-                      "hard_bounce",
-                      "soft_bounce",
+                      "hard-bounce",
+                      "soft-bounce",
                       "spam",
                       "unsub",
                       "custom",
@@ -3364,8 +3364,8 @@
                     "type": "string",
                     "description": "the reason for the rejection if the recipient status is \"rejected\"",
                     "enum": [
-                      "hard_bounce",
-                      "soft_bounce",
+                      "hard-bounce",
+                      "soft-bounce",
                       "spam",
                       "unsub",
                       "custom",


### PR DESCRIPTION
### Description

Updated the "reject_reasons" response for /messages/send and /messages/send-template to correctly use "hard-bounce" and "soft-bounce" instead of the previously stated "hard_bounce" and "soft_bounce".