### PR TITLE
Update superagent npm dependency

### DIFF
--- a/swagger-config/marketing/javascript/templates/package.mustache
+++ b/swagger-config/marketing/javascript/templates/package.mustache
@@ -11,7 +11,7 @@
     "fs": false
   },
   "dependencies": {
-    "superagent": "3.8.1",
+    "superagent": "^8.0.0",
     "dotenv": "^8.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
### Description

The `superagent` dependency used (as well as its `formidable` dependency) is deprecated, leading to warnings on every npm install using `@mailchimp/mailchimp_marketing`.

Judging from https://github.com/visionmedia/superagent#upgrading-from-previous-versions, there should be no breaking changes and my own tests consuming `@mailchimp/mailchimp_marketing` are still running fine.

### Known Issues

I'm unable to run `npm run generate` on my machine, it exits with the following error:
```
[main] ERROR io.swagger.codegen.DefaultGenerator - Could not process model 'inline_response_200_14'. Please make sure that your schema is correct!
java.lang.NullPointerException: Cannot read field "isContainer" because "cp" is null
```

This might be related to using `swagger-codegen@3.0.34` due to v2 not being installable on my ARM Apple.