### PR TITLE
Update gh-action-pypi-publish branch in workflows

### DIFF
--- a/.github/workflows/create-release-marketing.yml
+++ b/.github/workflows/create-release-marketing.yml
@@ -625,7 +625,7 @@ jobs:
 
       - name: Publish → PyPI → marketing-python (test)
         if: env.PUBLISH_EXTERNAL == 'true'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN_TEST }}
           repository_url: https://test.pypi.org/legacy/
@@ -633,7 +633,7 @@ jobs:
 
       - name: Publish → PyPI → marketing-python (dist)
         if: env.PUBLISH_EXTERNAL == 'true'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: marketing-python/dist

--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -611,7 +611,7 @@ jobs:
 
       - name: Publish → PyPI → transactional-python (test)
         if: env.PUBLISH_EXTERNAL == 'true'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN_TEST }}
           repository_url: https://test.pypi.org/legacy/
@@ -619,7 +619,7 @@ jobs:
 
       - name: Publish → PyPI → marketing-python (dist)
         if: env.PUBLISH_EXTERNAL == 'true'
-        uses: pypa/gh-action-pypi-publish@master
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_TOKEN }}
           packages_dir: transactional-python/dist


### PR DESCRIPTION
### Description
The `master` branch on https://github.com/pypa/gh-action-pypi-publish has been deprecated. Update our workflows to the new `release/v1` branch instead.

