### PR TITLE
Added a field to various responses when messages are queued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.50
+* Added a response parameter to /messages/send and /messages/send-template called 'queued_response' that details why an email was queued.
+
 ### 1.0.48
 * Allowing users to schedule messages (using messages/send, messages/send-template, messages/send-raw and messages/reschedule APIs) within a year from the date of scheduling.
 

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -177,7 +177,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.49",
+    "version": "1.0.50",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",
@@ -2988,6 +2988,19 @@
                       "rule"
                     ]
                   },
+                  "queued_reason": {
+                    "type": "string",
+                    "description": "the reason for the email being queued if the response status is \"queued\"",
+                    "enum": [
+                      "free-trial-sends-exhausted",
+                      "hourly-quota-exhausted",
+                      "monthly-limit-reached",
+                      "sending-paused",
+                      "sending-suspended",
+                      "account-suspended",
+                      "sending-backlogged"
+                    ]
+                  },
                   "_id": {
                     "type": "string",
                     "description": "the message's unique id"
@@ -3374,6 +3387,19 @@
                       "test-mode-limit",
                       "unsigned",
                       "rule"
+                    ]
+                  },
+                  "queued_reason": {
+                    "type": "string",
+                    "description": "the reason for the email being queued if the response status is \"queued\"",
+                    "enum": [
+                      "free-trial-sends-exhausted",
+                      "hourly-quota-exhausted",
+                      "monthly-limit-reached",
+                      "sending-paused",
+                      "sending-suspended",
+                      "account-suspended",
+                      "sending-backlogged"
                     ]
                   },
                   "_id": {

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -2992,6 +2992,8 @@
                     "type": "string",
                     "description": "the reason for the email being queued if the response status is \"queued\"",
                     "enum": [
+                      "attachments",
+                      "multiple-recipients",
                       "free-trial-sends-exhausted",
                       "hourly-quota-exhausted",
                       "monthly-limit-reached",
@@ -3393,6 +3395,8 @@
                     "type": "string",
                     "description": "the reason for the email being queued if the response status is \"queued\"",
                     "enum": [
+                      "attachments",
+                      "multiple-recipients",
                       "free-trial-sends-exhausted",
                       "hourly-quota-exhausted",
                       "monthly-limit-reached",


### PR DESCRIPTION
## Description
We've dded a response parameter to `/messages/send` and `/messages/send-template` called 'queued_response' that details why an email was queued. 

The possible values are:

```
attachments
multiple-recipients
free-trial-sends-exhausted
hourly-quota-exhausted
monthly-limit-reached
sending-paused
sending-suspended
account-suspended
sending-backlogged
```
