### PR TITLE
[transactional-node] Bump axios to 1.3

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -177,7 +177,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.50",
+    "version": "1.0.51",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/transactional/javascript/templates/package.mustache
+++ b/swagger-config/transactional/javascript/templates/package.mustache
@@ -8,7 +8,7 @@
     "fs": false
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^1.1.3"
   },
   "homepage": "https://github.com/mailchimp/mailchimp-transactional-node",
   "repository": {


### PR DESCRIPTION
### Description
Update the transactional-node  dependency on axios to the latest version. 
### Known Issues
There doesn't seem to any known issues, or issues upgrading. The current usage of axios in the node-transactional package is limited to `axios.post().then().catch()` which doesn't seem to have changed between v0.2 and v1.3
