### PR TITLE
Disable default body and content limits set by axios library

### DIFF
--- a/swagger-config/transactional/javascript/templates/ApiClient.mustache
+++ b/swagger-config/transactional/javascript/templates/ApiClient.mustache
@@ -48,7 +48,10 @@ exports.prototype.post = function post(path, body = {}) {
   }
 
   return axios
-    .post(url, body)
+    .post(url, body, {
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity
+    })
     .then(function (response) {
       return response.data;
     })


### PR DESCRIPTION
### Description

When the mail body is larger than the maximum limit defined by axios, the request is failed with `Request body larger than maxBodyLength limit` error message. Actually, mails could be higher than the limits defined by axios so it is better not to have any kind of limits in terms of the size. 

### Known Issues

N/A
