### PR TITLE
Parse ruby error response body and add attributes

### DIFF
--- a/swagger-config/marketing/ruby/templates/api_error.mustache
+++ b/swagger-config/marketing/ruby/templates/api_error.mustache
@@ -2,29 +2,55 @@
 {{> api_info}}
 =end
 
-module {{moduleName}}
+require 'json'
+
+module MailchimpMarketing
   class ApiError < StandardError
     attr_reader :status, :type, :title, :detail, :instance, :errors
+
+    attr_reader :response_headers, :response_body
 
     # Usage examples:
     #   ApiError.new
     #   ApiError.new("message")
     #   ApiError.new(:status => 500, :response_headers => {}, :response_body => "")
     #   ApiError.new(:status => 404, :message => "Not Found")
-    def initialize(arg = nil)
-      if arg.is_a? Hash
-        if arg.key?(:message) || arg.key?('message')
-          super(arg[:message] || arg['message'])
-        else
-          super arg
-        end
+    def initialize(arguments = nil)
+      @arguments = arguments
+      return super(@arguments) unless @arguments.is_a?(Hash)
 
-        arg.each do |k, v|
-          instance_variable_set "@#{k}", v
-        end
-      else
-        super arg
+      @arguments.transform_keys!(&:to_sym)
+
+      expand_response_body_into_arguments
+
+      super(@arguments[:title] || @arguments[:message])
+
+      @arguments.each do |key, value|
+        instance_variable_set("@#{key}", value)
       end
     end
+
+    private
+
+    def expand_response_body_into_arguments
+      @arguments.merge!(parsed_response_body) unless parsed_response_body.nil?
+    end
+
+    def parsed_response_body
+      @parsed_response_body ||= begin
+        parsed_response_body = JSON.parse(@arguments[:response_body]).transform_keys(&:to_sym)
+
+        if parsed_response_body[:errors].is_a?(Array)
+          parsed_response_body[:errors].map do |error|
+            error.transform_keys!(&:to_sym)
+          end
+        end
+
+        parsed_response_body
+      rescue
+        nil
+      end
+    end
+
   end
 end


### PR DESCRIPTION
### Description

This PR is based on [a PR I originally opened on the generated mailchimp-marketing-ruby gem](https://github.com/mailchimp/mailchimp-marketing-ruby/pull/5) in 2021. At the time I didn't know that the gem was generated and the PR was rejected several months later. I never got around to submitting the patch to this project and have been using my own fork. However, I would like to see if my change could make it into this repo.

This PR should generally be backwards compatible, with the exception that the error _message_ won't show a stringified version of a ruby hash.

**Here's the summary from the original PR on the wrong repo:**

The `MailchimpMarketing::ApiError` is used to wrap up error responses from the Mailchimp API. This class is used to raise errors encountered by the `ApiClient` class. In the case that we have a response body, the body's json is parsed into a hash and this hash is passed in as a named argument to the `ApiError` constructor. In the case that a hash is provided to the `ApiErrors` constructor (and the hash doesn't have a `:message` key), it is simply passed to `StandardError` constructor.

Because a hash is being passed to the `StandardError` constructor, the `message` value of the resulting error is the result of calling `to_s` on the hash. EG:

```
pry(#<ListsController>)> error.message
=> "{:status=>401, :response_body=>\"{\\\"type\\\":\\\"http://developer.mailchimp.com/documentation/mailchimp/guides/error-glossary/\\\",\\\"title\\\":\\\"API Key Invalid\\\",\\\"status\\\":401,\\\"detail\\\":\\\"Your API key may be invalid, or you've attempted to access the wrong datacenter.\\\",\\\"instance\\\":\\\"ff205bd4-c256-4570-aaf0-6764d0032a8a\\\"}\"}"
```

Note that the value of `message` is definitely not JSON. 😄 

The `ApiError` class' constructor _does_ take all of the named values provided to the constructor and store them as instance variables. 

It would be nice to have access to the response body, if available. I do not feel comfortable calling `eval` on the hash stored in `message`, especially since this could potentially be a string. I do not want to use `instance_variable_get` to read the instance variable, since this would break encapsulation.

As such, this PR simply introduces a new `attr_reader` for `:response_headers` and `:response_body`. Now this data is safely accessible from outside of the error class. 

As a note, there are no uses of `:response_header` in this gem. However, the comments in the `ApiError` comments show this as an example option, so I added the reader. This doesn't cover any cases where other non-standard attributes are provided to the constructor. 

### Known Issues
