### PR TITLE
Fix compatible with php 8.2

### DIFF
--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -23,6 +23,9 @@ class Configuration
     protected $defaultOutputFormat = '';
     protected $timeout = 300;
 
+    {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}protected ${{#tags}}{{{name}}}{{/tags}};
+    {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+
     public static $formatList = ['json', 'xml', 'php', 'yaml'];
 
     public function __construct()

--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -23,7 +23,7 @@ class Configuration
     protected $defaultOutputFormat = '';
     protected $timeout = 300;
 
-    {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}protected ${{#tags}}{{{name}}}{{/tags}};
+    {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}public ${{#tags}}{{{name}}}{{/tags}};
     {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
     public static $formatList = ['json', 'xml', 'php', 'yaml'];

--- a/swagger-config/transactional/php/templates/api.mustache
+++ b/swagger-config/transactional/php/templates/api.mustache
@@ -34,7 +34,10 @@ use {{invokerPackage}}\ObjectSerializer;
  */
 {{#operations}}class {{classname}}
 {
-    protected $Configuration;
+    /**
+     * @var Configuration
+     */
+    protected $config;
 
     public function __construct(Configuration $config = null)
     {


### PR DESCRIPTION
Error occurs when using php 8.2
Creation of dynamic property MailchimpTransactional\Api\AllowlistsApi::$config is deprecated.