### PR TITLE
Update messages/send-template to remove the template name reference

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.51
+* Fixed `/messages/send-template` documentation where incorrectly referenced the template name usage.
+
 ### 1.0.50
 * Added a response parameter to /messages/send and /messages/send-template called 'queued_response' that details why an email was queued.
 

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -3046,7 +3046,7 @@
                 },
                 "template_name": {
                   "type": "string",
-                  "description": "the immutable name or slug of a template that exists in the user's account. For backwards-compatibility, the template name may also be used but the immutable slug is preferred."
+                  "description": "the immutable slug of a template that exists in the user's account. Make sure you don't use the template name as this one might change."
                 },
                 "template_content": {
                   "type": "array",

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -177,7 +177,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.50",
+    "version": "1.0.51",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -191,7 +191,6 @@
   "consumes": ["application/json"],
   "produces": [
     "application/json",
-    "application/xml",
     "application/x-php",
     "application/x-yaml; charset=utf-8"
   ],


### PR DESCRIPTION
### Description
This contribution fixes the incorrect template name usage in favor of the template slug which is the correct way.

### Known Issues
![image](https://github.com/mailchimp/mailchimp-client-lib-codegen/assets/3235376/6699b669-0a8d-4eed-ad10-09a646475684)
