### PR TITLE
Added setHost-method to PHP package

### DIFF
--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -53,6 +53,11 @@ class Configuration
         return $this->requestClient;
     }
 
+    public function setHost($host)
+    {
+        $this->host = $host;
+    }
+
     public function getHost()
     {
         return $this->host;


### PR DESCRIPTION
### Description
By developing our own clone of the Mandrill dashboard, we can resolve the recurring issue of Mandrill timeouts. To put it simply, the Mandrill servers are unreliable, leading to significant disruptions in our development process that can last for hours.

### Known Issues
