### PR TITLE
Allow a custom client to be configured and used

### DIFF
--- a/swagger-config/marketing/php/templates/Configuration.mustache
+++ b/swagger-config/marketing/php/templates/Configuration.mustache
@@ -10,7 +10,7 @@
 namespace {{invokerPackage}};
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}
 use {{invokerPackage}}\Api\{{classname}};{{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
-use Psr\Http\Client\ClientInterface;
+use GuzzleHttp\Client;
 
 class Configuration
 {
@@ -27,7 +27,7 @@ class Configuration
     protected $debugFile = 'php://output';
     protected $tempFolderPath;
     protected $timeout = 120;
-    protected ?ClientInterface $client = null;
+    protected ?Client $client = null;
 
     public function __construct()
     {
@@ -63,12 +63,12 @@ class Configuration
         return $this;
     }
 
-    public function setClient(ClientInterface $client): void
+    public function setClient(Client $client): void
     {
         $this->client = $client;
     }
 
-    public function getClient(): ?ClientInterface
+    public function getClient(): ?Client
     {
         return $this->client;
     }

--- a/swagger-config/marketing/php/templates/Configuration.mustache
+++ b/swagger-config/marketing/php/templates/Configuration.mustache
@@ -10,6 +10,7 @@
 namespace {{invokerPackage}};
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}
 use {{invokerPackage}}\Api\{{classname}};{{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+use Psr\Http\Client\ClientInterface;
 
 class Configuration
 {
@@ -26,6 +27,7 @@ class Configuration
     protected $debugFile = 'php://output';
     protected $tempFolderPath;
     protected $timeout = 120;
+    protected ?ClientInterface $client = null;
 
     public function __construct()
     {
@@ -59,6 +61,16 @@ class Configuration
         }
 
         return $this;
+    }
+
+    public function setClient(ClientInterface $client): void
+    {
+        $this->client = $client;
+    }
+
+    public function getClient(): ?ClientInterface
+    {
+        return $this->client;
     }
 
     public function setApiKey($apiKeyIdentifier, $key)

--- a/swagger-config/marketing/php/templates/api.mustache
+++ b/swagger-config/marketing/php/templates/api.mustache
@@ -39,11 +39,16 @@ use {{invokerPackage}}\ObjectSerializer;
 
     public function __construct(Configuration $config = null)
     {
-        $this->client = new Client([
-            'defaults' => [
-                'timeout' => 120.0
-            ]
-        ]);
+        $this->client = $config->getClient();
+
+        if ($this->client === null) {
+            $this->client = new Client([
+                'defaults' => [
+                    'timeout' => 120.0,
+                ],
+            ]);
+        }
+
         $this->headerSelector = new HeaderSelector();
         $this->config = $config ?: new Configuration();
     }

--- a/swagger-config/marketing/php/templates/api.mustache
+++ b/swagger-config/marketing/php/templates/api.mustache
@@ -36,6 +36,7 @@ use {{invokerPackage}}\ObjectSerializer;
     protected $client;
     protected $config;
     protected $headerSelector;
+    protected ?Client $client;
 
     public function __construct(Configuration $config = null)
     {


### PR DESCRIPTION
### Description

Currently, it is impossible to inject our own Guzzle http client with its own configuration.
We see that a lot of `ConnectionException` occur and we would like to handle those through the Guzzle middlewares.
By allowing to set a custom client, we can facilitate this behaviour.

### Known Issues
