### PR TITLE
Bump axios to 1.6.2

### DIFF
--- a/swagger-config/transactional/javascript/templates/package.mustache
+++ b/swagger-config/transactional/javascript/templates/package.mustache
@@ -8,7 +8,7 @@
     "fs": false
   },
   "dependencies": {
-    "axios": "^0.21.1"
+    "axios": "^1.6.2"
   },
   "homepage": "https://github.com/mailchimp/mailchimp-transactional-node",
   "repository": {


### PR DESCRIPTION
### Description
Updated axios to 1.6.2 as it is outdated and open to vulnerabilities.
### Known Issues
No known issues.
