### PR TITLE
fixing ruby test and php SDK json form

### DIFF
--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -337,7 +337,7 @@ jobs:
           unzip zip/mailchimp-transactional-ruby.zip -d swagger-out/transactional-ruby
 
       - name: Set up Ruby 2.6
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.6'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Transactional
 
+### 1.0.53
+* Fixed broken ruby SDK test, updated PHP SDK to send form data via JSON
+
 ### 1.0.52
 * Added the `is_broken_template` response to the /template endpoints that include it
 

--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -177,7 +177,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.0.52",
+    "version": "1.0.53",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",

--- a/swagger-config/transactional/php/templates/Configuration.mustache
+++ b/swagger-config/transactional/php/templates/Configuration.mustache
@@ -93,7 +93,7 @@ class Configuration
 
         // prepare request params
         $postUrl = $this->getHost() . $path;
-        $options['form_params'] = $body;
+        $options['json'] = $body;
 
         // set output format
         $defaultOutputFormat = $this->getDefaultOutputFormat();


### PR DESCRIPTION
### Description
This fixes the ruby test that was broken and preventing new builds of the SDKs. It also updates the PHP SDK to use JSON in the requests instead of form_params.
