### PR TITLE
Update api.mustache to enforce that required params cannot be empty strings

### DIFF
--- a/swagger-config/marketing/python/templates/api.mustache
+++ b/swagger-config/marketing/python/templates/api.mustache
@@ -99,7 +99,8 @@ class {{classname}}(object):
 {{#required}}
         # verify the required parameter '{{paramName}}' is set
         if ('{{paramName}}' not in params or
-                params['{{paramName}}'] is None):
+                params['{{paramName}}'] is None or
+                params['{{paramName}}'] == ''):
             raise ValueError("Missing the required parameter `{{paramName}}` when calling `{{vendorExtensions.x-custom-config.methodNameSnake}}`")  # noqa: E501
 {{/required}}
 {{/allParams}}


### PR DESCRIPTION
### Description
This PR updates the required field checks to ensure that a required field value cannot be an empty string.

This may not be the right solution, it may be better to limit this value check to fields that are required in the path, since when provided in a query argument an empty string could be a completely valid value.  

### Known Issues
When calling an endpoint like `GET /lists/<list_id>`, if the list_id provided is an empty string, the python api client ends up calling `GET /lists/` instead, which results in fetching a different set of data than intended. 

This should be able to be reproduced by running something like
```
response = client.lists.get_list('')
```
instead of getting a client error or a 404, you'll get back the full set of lists, as if the call made was `client.lists.get_lists()`.  This is unexpected, since the call is clearly made to get a single list, and any assumptions that are made about the shape of the data returned in the response will be incorrect.