### PR TITLE
specific ruby version and latest actions/cache

### DIFF
--- a/.github/workflows/create-release-transactional.yml
+++ b/.github/workflows/create-release-transactional.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Cache node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -46,7 +46,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
@@ -65,13 +65,13 @@ jobs:
 
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
 
       - name: Cache node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -119,13 +119,13 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
 
       - name: Cache node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -162,13 +162,13 @@ jobs:
 
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
 
       - name: Cache node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -205,13 +205,13 @@ jobs:
 
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
 
       - name: Cache node_modules
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         env:
           cache-name: cache-node-modules
         with:
@@ -280,7 +280,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-mc
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
@@ -321,7 +321,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-mc
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
@@ -365,7 +365,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-mc
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
@@ -470,7 +470,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
@@ -509,7 +509,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir
@@ -517,7 +517,7 @@ jobs:
       - name: Install Ruby 2.6.x
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.6.10
 
       - name: Prepare Build & Publishing Tools
         run: |
@@ -567,7 +567,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Initialize Transactional Cache
         id: init-cache-md
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: .cache
           key: cache-dir


### PR DESCRIPTION
### Description
Adding ruby version 2.6.10 so that publish_ruby job succeeds
Using the latest actions/cache@v4 to get rid of the warnings in github workflow

### Known Issues
