### PR TITLE
Use commonjs axios build for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,5 +47,10 @@
   },
   "devDependencies": {
     "edit-json-file": "^1.4.0"
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^axios$": "axios/dist/node/axios.cjs"
+    }
   }
 }


### PR DESCRIPTION
### Description

Since the Axios upgrade to v1 we need to use the commonjs version when running tests

### Known Issues
