### PR TITLE
add public properties for php 8.2 support

### DIFF
--- a/swagger-config/marketing/php/templates/Configuration.mustache
+++ b/swagger-config/marketing/php/templates/Configuration.mustache
@@ -26,6 +26,8 @@ class Configuration
     protected $debugFile = 'php://output';
     protected $tempFolderPath;
     protected $timeout = 120;
+    {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}public ${{#tags}}{{{name}}}{{/tags}};
+    {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
 
     public function __construct()
     {


### PR DESCRIPTION
### Description

Similar to #348, but for the marketing API

See https://php.watch/versions/8.2/dynamic-properties-deprecated for why this is necessary.