### PR TITLE
ApiClient: don't override global axios timeout

### DIFF
--- a/swagger-config/transactional/javascript/templates/ApiClient.mustache
+++ b/swagger-config/transactional/javascript/templates/ApiClient.mustache
@@ -1,7 +1,10 @@
 {{>licenseInfo}}
 var axios = require('axios');
 
-axios.defaults.timeout = 300000; // 300s
+var axiosInstance = axios.create({
+  timeout: 300000 // 300s
+});
+
 
 {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}var {{baseName}} = require('./api/{{classname}}');
 {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
@@ -47,7 +50,7 @@ exports.prototype.post = function post(path, body = {}) {
     url = url + '.' + defaultOutputFormat;
   }
 
-  return axios
+  return axiosInstance
     .post(url, body)
     .then(function (response) {
       return response.data;
@@ -66,7 +69,7 @@ exports.prototype.setDefaultOutputFormat = function (outputFormat) {
 };
 
 exports.prototype.setDefaultTimeoutMs = function (timeoutMs) {
-  axios.defaults.timeout = timeoutMs;
+  axiosInstance.defaults.timeout = timeoutMs;
 }
 
 // The default API client implementation.


### PR DESCRIPTION
### Description

Currently the ApiClient overrides the global axios timeout to 300s which is not expected, instead - create an axios instance and use it.

### Known Issues

While migrating from `mandrill-api` npm package, we found that the mailchimp transactional is overriding axios global defaults, which is not expected. I would like to configure only mailchimp API actions timeout.