### PR TITLE
Generate code for marketing-php APIs variables

### DIFF
--- a/swagger-config/marketing/php/templates/Configuration.mustache
+++ b/swagger-config/marketing/php/templates/Configuration.mustache
@@ -27,6 +27,9 @@ class Configuration
     protected $tempFolderPath;
     protected $timeout = 120;
 
+    {{#apiInfo}}{{#apis}}{{#operations}}{{#operation}}{{#-first}}public ${{#tags}}{{{name}}}{{/tags}};
+    {{/-first}}{{/operation}}{{/operations}}{{/apis}}{{/apiInfo}}
+
     public function __construct()
     {
         $this->tempFolderPath = sys_get_temp_dir();


### PR DESCRIPTION
### Description
Generates the code for Marketing API that is breaking support for PHP 8.

### Known Issues
PHP 8 does not allow the property creation on-the-fly

See https://php.watch/versions/8.2/dynamic-properties-deprecated for why this is necessary.