### PR TITLE
Make space for new lists when running tests

### DIFF
--- a/tests/marketing-php/MarketingTest.php
+++ b/tests/marketing-php/MarketingTest.php
@@ -78,6 +78,11 @@ class MarketingTest extends \PHPUnit\Framework\TestCase
         $respA = $client->lists->getAllLists();
         $this->assertTrue(is_array($respA->lists));
 
+        // make space for a new list before creating it
+        foreach ($respA->lists as $list) {
+            $client->lists->deleteList($list->id);
+        }
+
         // 2. Create new list
         $listName = "TestListPhpA" . time();
         $respB = $client->lists->createList([


### PR DESCRIPTION
### Description
When running integration tests the code is making requests to test the lifecycle of audience lists
https://github.com/mailchimp/mailchimp-client-lib-codegen/actions/runs/10046417263/job/27766073530

This PR makes sure that after we run the assertion, the resources are liberated to continue the execution
