### PR TITLE
Bump axios version in javascript transactional client to 1.7.7

### DIFF
--- a/swagger-config/transactional/javascript/templates/package.mustache
+++ b/swagger-config/transactional/javascript/templates/package.mustache
@@ -8,7 +8,7 @@
     "fs": false
   },
   "dependencies": {
-    "axios": "^1.7.0"
+    "axios": "^1.7.7"
   },
   "homepage": "https://github.com/mailchimp/mailchimp-transactional-node",
   "repository": {


### PR DESCRIPTION
### Description

Addresses [this vulnerability](https://security.snyk.io/vuln/SNYK-JS-AXIOS-7361793).

### Known Issues

I did not manually test this package version change, but I reviewed the release notes for breaking changes compared to 1.7.0, and it's only a patch version bump.