### PR TITLE
Use SPDX license id in package.json

### DIFF
--- a/swagger-config/marketing/javascript/templates/package.mustache
+++ b/swagger-config/marketing/javascript/templates/package.mustache
@@ -2,7 +2,7 @@
   "name": "{{{projectName}}}",
   "version": "{{{projectVersion}}}",
   "description": "{{{projectDescription}}}",
-  "license": "{{licenseName}}",
+  "license": "{{projectLicenseName}}",
   "main": "{{sourceFolder}}{{#invokerPackage}}/{{invokerPackage}}{{/invokerPackage}}/index.js",
   "scripts": {
     "test": "jest --setupFiles dotenv/config"

--- a/swagger-config/transactional/javascript/templates/package.mustache
+++ b/swagger-config/transactional/javascript/templates/package.mustache
@@ -2,7 +2,7 @@
   "name": "{{{projectName}}}",
   "version": "{{{projectVersion}}}",
   "description": "{{{projectDescription}}}",
-  "license": "{{licenseName}}",
+  "license": "{{projectLicenseName}}",
   "main": "{{sourceFolder}}{{#invokerPackage}}/{{invokerPackage}}{{/invokerPackage}}/index.js",
   "browser": {
     "fs": false


### PR DESCRIPTION
### Description

`package.json` should include [SPDX license id](https://spdx.org/licenses/) in `license` field.

Hence: `Apache 2.0` → `Apache-2.0`.