### PR TITLE
Make Configuration parameter nullable

### DIFF
--- a/swagger-config/marketing/php/templates/Configuration.mustache
+++ b/swagger-config/marketing/php/templates/Configuration.mustache
@@ -41,9 +41,9 @@ class Configuration
 
     public function setConfig($config = array())
     {
-        $apiKey = isset($config['apiKey']) ? $config['apiKey'] : '';
-        $accessToken = isset($config['accessToken']) ? $config['accessToken'] : '';
-        $server = isset($config['server']) ? $config['server'] : 'invalid-server';
+        $apiKey = $config['apiKey'] ?? '';
+        $accessToken = $config['accessToken'] ?? '';
+        $server = $config['server'] ?? 'invalid-server';
         $host = str_replace('server', $server, $this->getHost());
 
         // Basic Authentication
@@ -74,7 +74,7 @@ class Configuration
 
     public function getApiKey($apiKeyIdentifier)
     {
-        return isset($this->apiKeys[$apiKeyIdentifier]) ? $this->apiKeys[$apiKeyIdentifier] : null;
+        return $this->apiKeys[$apiKeyIdentifier] ?? null;
     }
 
     public function setApiKeyPrefix($apiKeyIdentifier, $prefix)
@@ -85,7 +85,7 @@ class Configuration
 
     public function getApiKeyPrefix($apiKeyIdentifier)
     {
-        return isset($this->apiKeyPrefixes[$apiKeyIdentifier]) ? $this->apiKeyPrefixes[$apiKeyIdentifier] : null;
+        return $this->apiKeyPrefixes[$apiKeyIdentifier] ?? null;
     }
 
     public function setAccessToken($accessToken)

--- a/swagger-config/marketing/php/templates/Configuration.mustache
+++ b/swagger-config/marketing/php/templates/Configuration.mustache
@@ -220,19 +220,14 @@ class Configuration
 
     public function getApiKeyWithPrefix($apiKeyIdentifier)
     {
-        $prefix = $this->getApiKeyPrefix($apiKeyIdentifier);
         $apiKey = $this->getApiKey($apiKeyIdentifier);
 
         if ($apiKey === null) {
             return null;
         }
 
-        if ($prefix === null) {
-            $keyWithPrefix = $apiKey;
-        } else {
-            $keyWithPrefix = $prefix . ' ' . $apiKey;
-        }
+        $prefix = $this->getApiKeyPrefix($apiKeyIdentifier);
 
-        return $keyWithPrefix;
+        return $prefix === null ? $apiKey : $prefix . ' ' . $apiKey;
     }
 }

--- a/swagger-config/marketing/php/templates/api.mustache
+++ b/swagger-config/marketing/php/templates/api.mustache
@@ -37,7 +37,7 @@ use {{invokerPackage}}\ObjectSerializer;
     protected $config;
     protected $headerSelector;
 
-    public function __construct(Configuration $config = null)
+    public function __construct(?Configuration $config = null)
     {
         $this->client = new Client([
             'defaults' => [

--- a/swagger-config/transactional/php/templates/api.mustache
+++ b/swagger-config/transactional/php/templates/api.mustache
@@ -36,7 +36,7 @@ use {{invokerPackage}}\ObjectSerializer;
 {
     protected $config;
 
-    public function __construct(Configuration $config = null)
+    public function __construct(?Configuration $config = null)
     {
         $this->config = $config ?: new Configuration();
     }


### PR DESCRIPTION
### Description

In PHP 8.4, you need to specifically mention that the parameter is nullable when you default a parameter to null.

https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated

Also, a few refactors using null coalesce.