### PR TITLE
Update Ruby to use ruby/setup-ruby

### DIFF
--- a/.github/workflows/test-marketing.yml
+++ b/.github/workflows/test-marketing.yml
@@ -118,9 +118,10 @@ jobs:
           unzip zip/mailchimp-marketing-ruby.zip -d swagger-out/marketing-ruby
 
       - name: Set up Ruby 2.7
-        uses: actions/setup-ruby@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: '2.7'
+          bundler-cache: true
 
       - name: Install client dependencies
         run: gem install rspec


### PR DESCRIPTION
### Description
Update Ruby to use ruby/setup-ruby instead of the deprecated actions/setup-ruby

### Known Issues
