### PR TITLE
Do not limit `excon` version for ruby client

### DIFF
--- a/swagger-config/marketing/ruby/templates/gemspec.mustache
+++ b/swagger-config/marketing/ruby/templates/gemspec.mustache
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   {{/gemLicense}}
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
-  s.add_runtime_dependency 'excon', '>= 0.76.0', '<1'
+  s.add_runtime_dependency 'excon', '>= 0.76.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'

--- a/swagger-config/transactional/ruby/templates/gemspec.mustache
+++ b/swagger-config/transactional/ruby/templates/gemspec.mustache
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   {{/gemLicense}}
   s.required_ruby_version = "{{{gemRequiredRubyVersion}}}{{^gemRequiredRubyVersion}}>= 1.9{{/gemRequiredRubyVersion}}"
 
-  s.add_runtime_dependency 'excon', '>= 0.76.0', '<1'
+  s.add_runtime_dependency 'excon', '>= 0.76.0'
   s.add_runtime_dependency 'json', '~> 2.1', '>= 2.1.0'
 
   s.add_development_dependency 'rspec', '~> 3.6', '>= 3.6.0'


### PR DESCRIPTION
Previous attempt https://github.com/mailchimp/mailchimp-marketing-ruby/pull/7.

Allow people to upgrade their `excon` gem dependency. I looked through the gem's changelog (https://github.com/excon/excon/blob/master/changelog.txt) - nothing stood out, should work as before.