### PR TITLE
fix(transactional): restore URLs section in x-doc-structure

### DIFF
--- a/spec/transactional.json
+++ b/spec/transactional.json
@@ -159,6 +159,16 @@
           "/mctemplates/render"
         ]
       },
+      "urls": {
+        "title": "URLs",
+        "description": "Manage your tracking domains.",
+        "paths": [
+          "/urls/add-tracking-domain",
+          "/urls/check-tracking-domain",
+          "/urls/delete-tracking-domain",
+          "/urls/tracking-domains"
+        ]
+      },
       "users": {
         "title": "Users",
         "description": "Get information about your account, or ping Transactional.",
@@ -184,7 +194,7 @@
   },
   "swagger": "2.0",
   "info": {
-    "version": "1.4.0",
+    "version": "1.4.1",
     "title": "Mailchimp Transactional API",
     "contact": {
       "name": "API Support",


### PR DESCRIPTION
The `urls` resource was accidentally removed from `x-doc-structure` in #457, causing the entire URLs section to disappear from the dev site.

Restores the section with the 4 remaining tracking domain endpoints:
- `/urls/tracking-domains`
- `/urls/add-tracking-domain`
- `/urls/check-tracking-domain`
- `/urls/delete-tracking-domain`

(The 3 deprecated endpoints `/urls/list`, `/urls/search`, `/urls/time-series` are intentionally not restored.)